### PR TITLE
Rename offset to angle_offset in reconstruction

### DIFF
--- a/unfoog/config.py
+++ b/unfoog/config.py
@@ -54,7 +54,7 @@ class RecoParams(object):
         self.darks = self._config.value('general', 'darks')
         self.flats = self._config.value('general', 'flats')
         self.angle = self._config.value('general', 'angle', target=float)
-        self.offset = self._config.value('general', 'angle_offset', 0)
+        self.angle_offset = self._config.value('general', 'angle_offset', 0)
         self.dry_run = False
         self.enable_tracing = False
 
@@ -78,7 +78,7 @@ class RecoParams(object):
                             default=self.angle,
                             help="Angle step between projections in radians")
         parser.add_argument('--offset', type=float,
-                            default=self.offset,
+                            default=self.angle_offset,
                             help="Angle offset of first projection in radians")
         parser.add_argument('--enable-tracing', action='store_true', default=False,
                             help="Enable tracing and store result in .PID.json")

--- a/unfoog/reco.py
+++ b/unfoog/reco.py
@@ -79,9 +79,9 @@ def tomo(params):
         if params.angle:
             bp.props.angle_step = params.angle
 
-        if params.offset:
-            print params.offset
-            bp.props.angle_offset = params.offset
+        if params.angle_offset:
+            print params.angle_offset
+            bp.props.angle_offset = params.angle_offset
 
         if params.crop_width:
             ifft.props.crop_width = int(params.crop_width)
@@ -177,7 +177,7 @@ def lamino(params):
                         height=params.pad[1] / params.downsample,
                         fwidth=vx, theta=params.tilt, tau=params.tau)
 
-    rec.set_properties(theta=params.tilt, angle_step=params.angle, psi=params.offset,
+    rec.set_properties(theta=params.tilt, angle_step=params.angle, psi=params.angle_offset,
                        proj_ox=params.axis[0] / params.downsample,
                        proj_oy=params.axis[1] / params.downsample,
                        vol_sx=vx, vol_sy=vy, vol_sz=vz,


### PR DESCRIPTION
to remove ambiguity since now there are both angle_offset
and offset which specifies the offset of the sinogram row
with respect to the first projection.

However I didn't add the offset to the params for the script because I don't think someone will use the incremental backprojection with the script.
