### PR TITLE
Enable multipass execution

### DIFF
--- a/bin/ufo-sinos
+++ b/bin/ufo-sinos
@@ -13,6 +13,10 @@ def main():
     parser.add_argument('--flats', metavar='PATH', type=str)
     parser.add_argument('--darks', metavar='PATH', type=str)
     parser.add_argument('--disable-absorption-correction', action='store_true')
+    parser.add_argument('--num', dest='num_sinos', type=int, default=0,
+                        help='Number of sinograms conatined in the data')
+    parser.add_argument('--pass-size', dest='chunk', type=int, default=0,
+                        help='Number of sinograms to process per pass')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
To save memory it is sometimes better not to process all the sinograms at once.
