### PR TITLE
Enable specifying filter type

### DIFF
--- a/tofu/config.py
+++ b/tofu/config.py
@@ -103,7 +103,12 @@ SECTIONS['reconstruction'] = {
     'angle': {
         'default': None,
         'type': float,
-        'help': "Angle step between projections in radians"}}
+        'help': "Angle step between projections in radians"},
+    'projection-filter': {
+        'default': 'ramp',
+        'type': str,
+        'help': "Projection filter",
+        'choices': ['ramp', 'butterworth', 'faris-byer']}}
 SECTIONS['tomographic-reconstruction'] = {
     'axis': {
         'default': None,

--- a/tofu/reco.py
+++ b/tofu/reco.py
@@ -60,7 +60,7 @@ def tomo(params):
     if params.method == 'fbp':
         fft = get_task('fft', dimensions=1)
         ifft = get_task('ifft', dimensions=1)
-        fltr = get_task('filter')
+        fltr = get_task('filter', filter=params.projection_filter)
         bp = get_task('backproject')
 
         if params.axis:


### PR DESCRIPTION
PR because of the name, is `projection-filter` OK? I don't want to have just `filter`.