### PR TITLE
Fuse phase retrieval and FBP filter

### DIFF
--- a/tofu/config.py
+++ b/tofu/config.py
@@ -175,6 +175,22 @@ SECTIONS['retrieve-phase'] = {
         'help': "Real part of the complex refractive index of the material. "
                 "If specified, phase retrieval returns projected thickness, "
                 "if not, it returns phase"},
+    'tie-approximate-logarithm': {
+        'default': False,
+        'help': ("Approximate the logarithm of the tie method by the first order Taylor series "
+                 "expansion [ln(x) ~ ln(a) + (x - a) / a at a, a specified with "
+                 "--tie-approximate-point].  This way we may do the filtering for FBP already "
+                 "by the phase retrieval and save one forward and one backward 1D FFT needed "
+                 "if the filtering occurse separately. This is mostly useful for online reconstruction "
+                 "when one reconstruct only a few slices."),
+        'action': 'store_true'},
+    'tie-approximate-point': {
+        'default': 0.75,
+        'type': float,
+        'help': ("Taylor series point of expansion used by --tie-approximate-logarithm. "
+                 "The error of the approximation will be smallest around this point, "
+                 "so you can tune this for the desired grey level of interest "
+                 "(given by the sample based on e^(-mju * projected_thickness)).")},
     'retrieval-padded-width': {
         'default': 0,
         'type': restrict_value((0, None), dtype=int),

--- a/tofu/genreco.py
+++ b/tofu/genreco.py
@@ -410,6 +410,9 @@ class Executor(object):
 
     def process(self):
         self.scheduler = Ufo.FixedScheduler()
+        if hasattr(self.scheduler.props, 'enable_tracing'):
+            LOG.debug("Use tracing: {}".format(self.args.enable_tracing))
+            self.scheduler.props.enable_tracing = self.args.enable_tracing
         self.scheduler.set_resources(self.resources)
         graph = Ufo.TaskGraph()
         gpu = self.scheduler.get_resources().get_gpu_nodes()[self.gpu_index]

--- a/tofu/util.py
+++ b/tofu/util.py
@@ -320,6 +320,18 @@ def run_scheduler(scheduler, graph):
         return False
 
 
+def fbp_filtering_in_phase_retrieval(args):
+    if args.energy is None or args.propagation_distance is None:
+        # No phase retrieval at all
+        return False
+    return (
+        args.projection_filter != 'none' and (
+            args.retrieval_method != 'tie' or
+            args.tie_approximate_logarithm
+        )
+    )
+
+
 class Vector(object):
 
     """A vector based on axis-angle representation."""


### PR DESCRIPTION
This saves one 1D FFT and IFFT pair when using phase retrieval because we can apply the ramp filter also in the 2D FFT domain. For the reconstruction of many slices this won't help much, but for online reconstruction when one reconstructs just a couple of slices it will save some time.