### PR TITLE
Add --output-rescale

### DIFF
--- a/tofu/config.py
+++ b/tofu/config.py
@@ -41,6 +41,11 @@ SECTIONS['general'] = {
         'type': float,
         'help': "Maximum input value that maps to largest output value",
         'metavar': 'MAX'},
+    'output-rescale': {
+        'default': False,
+        'action': 'store_true',
+        'help': "If true rescale grey values either automatically or according to set "
+                "--output-minimum and --output-maximum"},
     'output-bytes-per-file': {
         'default': '128g',
         'type': convert_filesize,

--- a/tofu/tasks.py
+++ b/tofu/tasks.py
@@ -23,7 +23,7 @@ def get_writer(params):
 
     outname = params.output
     LOG.debug("Writing output to {}".format(outname))
-    writer = get_task('write', filename=outname)
+    writer = get_task('write', filename=outname, rescale=params.output_rescale)
 
     writer.props.append = params.output_append
 


### PR DESCRIPTION
and by default do not rescale the output. @sgasilov the rescale was actually happening by default, this PR makes it so that when you do not specify `--output-rescale` it won't happen, otherwise yes, i.e. the old behavior.