### PR TITLE
Add missing scikit-image dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
         'pyqtconsole',
         'pyxdg',
         'qtpynodeeditor',
-        'tifffile'
+        'tifffile',
+        'scikit-image',
     ],
     description="A fast, versatile and user-friendly image "\
                 "processing toolkit for computed tomography",


### PR DESCRIPTION
Used in `tofu.find_large_spots` and `tofu.ez.Helpers.stitch_funcs`