### PR TITLE
ez: Fix get_pr_tofu_cmd() when flats2 not present

### DIFF
--- a/tofu/ez/Helpers/find_360_overlap.py
+++ b/tofu/ez/Helpers/find_360_overlap.py
@@ -238,13 +238,12 @@ def make_sinos_PR(ctset, dirflats, dirdark, dirflats2, ax_range, sin_tmp_dir):
         dirflats = os.path.join(par_dir, dirflats)
         dirtomo = os.path.join(par_dir, 'proj-step1')
         dirflats2 = os.path.join(par_dir, dirflats2)
-        typ = 3
-        if os.path.exists(dirflats2):
-            typ = 4
+        if not os.path.exists(dirflats2):
+            dirflats2 = None
         par_dir = os.path.join(EZVARS_aux['find360olap']['tmp-dir']['value'], 'stitched-pr', f"{axis:04}")
         out_pattern = os.path.join(par_dir, "proj-%04i.tif")
         print(f"Phase retrieval")
-        cmd = fmt_pr_cmd(dirdark, dirflats, dirtomo, typ, dirflats2, out_pattern)
+        cmd = fmt_pr_cmd(dirdark, dirflats, dirtomo, dirflats2, out_pattern)
         os.system(cmd)
         print(f"Generating sinogram for the target row")
         cmd = "tofu sinos"

--- a/tofu/ez/tofu_cmd_gen.py
+++ b/tofu/ez/tofu_cmd_gen.py
@@ -247,15 +247,16 @@ def get_pr_tofu_cmd(ctset):
     # so we need a separate "universal" command which considers all previous steps
     in_proj_dir, out_pattern = fmt_in_out_path(EZVARS['inout']['tmp-dir']['value'],
                                                ctset[0], EZVARS['inout']['tomo-dir']['value'])
+    flats2_dir = indir[3] if ctset[1] == 4 else None
 
-    return fmt_pr_cmd(indir[0], indir[1], in_proj_dir, ctset[1], indir[3], out_pattern)
+    return fmt_pr_cmd(indir[0], indir[1], in_proj_dir, flats2_dir, out_pattern)
 
-def fmt_pr_cmd(darks_dir, flats_dir, tomo_dir, typ, darks2_dir, out_pattern):
+def fmt_pr_cmd(darks_dir, flats_dir, tomo_dir, flats2_dir, out_pattern):
     cmd = 'tofu preprocess --fix-nan-and-inf --projection-filter none --delta 1e-6'
     cmd += ' --darks {} --flats {} --reduction-mode median --projections {}'.\
                 format(darks_dir, flats_dir, tomo_dir)
-    if typ == 4:
-        cmd += ' --flats2 {}'.format(darks2_dir)
+    if flats2_dir:
+        cmd += ' --flats2 {}'.format(flats2_dir)
     cmd += ' --output {}'.format(out_pattern)
     cmd += ' --energy {} --propagation-distance {}' \
            ' --pixel-size {} --regularization-rate {:0.2f}' \


### PR DESCRIPTION
When dataset is "Type 3" (no `flats2` folder), `make_inpaths` returns a list of length 3, so `indir[3]` gives an `IndexError` in that case.

Introduced in e1cdc7ff