### PR TITLE
Print usage when no arguments are passed

### DIFF
--- a/bin/tofu
+++ b/bin/tofu
@@ -223,8 +223,12 @@ def main():
         cmd_parser.set_defaults(_func=func)
 
     args = config.parse_known_args(parser, subparser=True)
+    try:
+        log_level = logging.DEBUG if args.verbose else logging.INFO
+    except AttributeError:
+        parser.print_usage()
+        return
 
-    log_level = logging.DEBUG if args.verbose else logging.INFO
     LOG.setLevel(log_level)
 
     stream_handler = logging.StreamHandler(sys.stdout)


### PR DESCRIPTION
I installed tofu on some servers and for testing if it worked I tried to start tofu without any argument (which does not make any sense, but I did not think about it). In this case, you get this error message:
```python
Traceback (most recent call last):
  File "~/.local/bin/tofu", line 227, in main
    log_level = logging.DEBUG if args.verbose else logging.INFO
                                 ^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'verbose'
```
This error message confused me way too long...

This commit catches the case and prints the usage message instead.