### PR TITLE
maint: devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+// For format details, see https://containers.dev/implementors/json_reference/
+{
+    "name": "Tofu Developer Container",
+    "build": {
+        "dockerfile": "../Dockerfile",
+        "target": "developer"
+    },
+    "remoteEnv": {
+        // Allow X11 apps to run inside the container
+        "DISPLAY": "${localEnv:DISPLAY}"
+    },
+    "customizations": {
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "python.defaultInterpreterPath": "/venv/bin/python"
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "ms-python.python",
+                // "github.vscode-github-actions",
+                // "tamasfe.even-better-toml",
+                // "redhat.vscode-yaml",
+                // "ryanluker.vscode-coverage-gutters",
+                // "charliermarsh.ruff",
+                // "ms-azuretools.vscode-docker"
+            ]
+        }
+    },
+    "runArgs": [
+        // Allow the container to access the host X11 display and EPICS CA
+        "--net=host",
+        // Make sure SELinux does not disable with access to host filesystems like tmp
+        "--security-opt=label=disable",
+        // Enable GPU access (via CDI)
+        "--device=nvidia.com/gpu=all"
+    ],
+    // Mount the parent as /workspaces so we can pip install peers as editable
+    "workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspaces,type=bind",
+    // After the container is created, install the python project in editable form
+    "postCreateCommand": "pip install $([ -f dev-requirements.txt ] && echo '-c dev-requirements.txt') -e '.[dev]' && pre-commit install"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,5 +38,5 @@
     // Mount the parent as /workspaces so we can pip install peers as editable
     "workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspaces,type=bind",
     // After the container is created, install the python project in editable form
-    "postCreateCommand": "pip install $([ -f dev-requirements.txt ] && echo '-c dev-requirements.txt') -e '.[dev]' && pre-commit install"
+    "postCreateCommand": "pip install $([ -f dev-requirements.txt ] && echo '-c dev-requirements.txt') -e '.'"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,7 @@ ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
 RUN git clone --depth 1 https://github.com/ufo-kit/ufo-core.git --branch ${UFO} && \
-    git clone --depth 1 https://github.com/ufo-kit/ufo-filters.git --branch ${UFO_FILTERS} && \
-    git clone --depth 1 https://github.com/ufo-kit/tofu --branch master
+    git clone --depth 1 https://github.com/ufo-kit/ufo-filters.git --branch ${UFO_FILTERS}
 
 RUN cd /ufo-core && meson build --libdir=lib -Dbashcompletiondir=$HOME/.local/share/bash-completion/completions && cd build && ninja install
 RUN cd /ufo-filters && \
@@ -86,7 +85,6 @@ ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
 # Things to remove
 COPY requirements-ufo.txt /
-COPY --from=ufo-builder /tofu /tofu
 
 # Required for ufo-core/python meson build to find ufo
 ENV LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH
@@ -104,8 +102,36 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir setuptools && \
     pip install --no-cache-dir -r /requirements-ufo.txt && \
-    pip install --no-cache-dir /ufo-core/python && \
-    pip install --no-cache-dir -r /tofu/requirements-flow.txt && \
-    pip install --no-cache-dir /tofu
+    pip install --no-cache-dir /ufo-core/python
 
-RUN rm -rf /ufo-core /ufo-filters /tofu
+RUN rm -rf /ufo-core
+
+# The build stage installs the context into the venv
+FROM developer AS build
+COPY . /context
+WORKDIR /context
+RUN touch dev-requirements.txt && pip install -c dev-requirements.txt .
+
+# The runtime stage copies the built venv into a slim runtime container
+FROM python:${PYTHON_VERSION}-slim AS runtime
+
+COPY --from=ufo-builder /usr/local/ /usr/local/
+COPY --from=build /opt/venv /opt/venv/
+# Add apt-get system dependecies for runtime here
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libjson-glib-dev \
+    libgirepository-1.0-1 \
+    libclfft2 \
+    ocl-icd-libopencl1 \
+    # qt5
+    libqt5gui5 \
+    dbus \
+    && rm -rf /var/lib/apt/lists/*
+
+# OpenCL nvidia
+RUN mkdir -p /etc/OpenCL/vendors && \
+    echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+ENV GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0:$GI_TYPELIB_PATH
+ENV PATH=/opt/venv/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ocl-icd-opencl-dev \
     # runtime
     libclfft2 \
+    libhdf5-103-1 \
+    libzmq5 \
     # ocl-icd-libopencl1 \ # runtime
     # libjson-glib-1.0-0 \ # runtime
     # qt5
@@ -123,6 +125,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgirepository-1.0-1 \
     libclfft2 \
     ocl-icd-libopencl1 \
+    libhdf5-103-1 \
+    libzmq5 \
     # qt5
     libqt5gui5 \
     dbus \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+FROM debian:12-slim
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY requirements-ufo.txt /
+
+RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
+        # General build requirements
+        apt-utils \
+        build-essential \
+        meson \
+        ninja-build \
+        git \
+        # ufo-core
+        asciidoc-base \
+        bash-completion \
+        cmake \
+        gobject-introspection \
+        # gtk-doc-tools \
+        libgirepository1.0-dev \
+        libglib2.0-dev \
+        libjson-glib-dev \
+        libzmq3-dev \
+        ocl-icd-opencl-dev \
+        # ufo-filters
+        libclfft-dev \
+        libgsl-dev \
+        libhdf5-dev \
+        libtiff-dev \
+        # ufo-core python
+        && apt-get install -y \
+        python3-dev \
+        python3-venv \
+        libcairo2-dev \
+        python-gi-dev \
+        # qt5
+        && apt-get install -y --no-install-recommends \
+        libqt5gui5 \
+        dbus \
+        && rm -rf /var/lib/apt/lists/*
+
+ENV LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH
+ENV GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0:$GI_TYPELIB_PATH
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+
+RUN mkdir -p /etc/OpenCL/vendors && \
+    echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+RUN git clone --depth 1 https://github.com/ufo-kit/ufo-core.git --branch master && \
+    git clone --depth 1 https://github.com/ufo-kit/ufo-filters.git --branch master && \
+    git clone --depth 1 https://github.com/ufo-kit/tofu --branch master
+
+RUN cd /ufo-core && meson build --libdir=lib -Dbashcompletiondir=$HOME/.local/share/bash-completion/completions && cd build && ninja install
+RUN cd /ufo-filters && \
+    sed -i -E "s/find_program.'python/find_program('python3/" src/meson.build && sed -i -E "s/find_program.'python/find_program('python3/" tests/meson.build && \
+    meson build --libdir=lib -Dcontrib_filters=True && cd build && ninja install
+
+# Use a venv to avoid interfering with system Python.
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+# This is equivalent to `source $VIRTUAL_ENV/bin/activate` but it
+# persists into the runtime so we avoid the need to account for it
+# in ENTRYPOINT or CMD.
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir setuptools && \
+    pip install --no-cache-dir -r /requirements-ufo.txt && \
+    pip install --no-cache-dir /ufo-core/python && \
+    pip install --no-cache-dir -r /tofu/requirements-flow.txt && \
+    pip install --no-cache-dir /tofu
+
+RUN rm -rf /ufo-core /ufo-filters /tofu

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12-slim
+FROM debian:12-slim as developer
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY requirements-ufo.txt /

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+# devcontainer constraints file
+pygobject~=3.50.0 # >=3.51.0 depends on libgirepository-2.0-dev

--- a/requirements-ufo.txt
+++ b/requirements-ufo.txt
@@ -1,0 +1,11 @@
+# ufo-core
+pygobject
+# ufo-filters/docs
+docutils==0.17.1
+jinja2==3.1.2
+sphinx==5.0.2
+sphinx-rtd-theme==1.0.0
+sphinxcontrib-bibtex
+# tofu
+pyqtgraph
+scikit-image

--- a/requirements-ufo.txt
+++ b/requirements-ufo.txt
@@ -1,5 +1,5 @@
 # ufo-core
-pygobject
+pygobject~=3.50.0 # >=3.51.0 depends on libgirepository-2.0-dev
 # ufo-filters/docs
 docutils==0.17.1
 jinja2==3.1.2


### PR DESCRIPTION
Dockerfile and .devcontainer config to simplify development and possibly deployment. If you open tofu git checkout in a IDE like VS Code/PyCharm, you get a working container development environment without any build difficulties.

I based the Dockerfile on ufo-kit/ufo-core, but it only targets Nvidia systems at the moment (and assumes you have the nvidia-container-toolkit installed on the host). However since UFO uses OpenCL this could likely be adapted to work on other systems.

One improvement I made was to split building the UFO image from the python image, and only copying build artifacts. This reduces the size of the final image and saves re-building UFO (which seems quite stable at the moment). This multi-build file enables building layers with just UFO, UFO+tofu, and a devcontainer: the `runtime` build should be appropriate for production use.

The `requirements-ufo.txt` (and exisiting requirements files) could probably be rationalized with a modern `pyproject.toml`.

See also https://github.com/sarkarchandan/ufo-docker/tree/master


