### PR TITLE
tofu ez: Flat-field correction: expose reduction mode setting

### DIFF
--- a/tofu/ez/GUI/Advanced/ffc.py
+++ b/tofu/ez/GUI/Advanced/ffc.py
@@ -77,8 +77,8 @@ class FFCGroup(QGroupBox):
 
         reduction_layout = QHBoxLayout()
         reduction_layout.addWidget(self.reduction_label)
-        reduction_layout.addWidget(self.median_reduction_rButton)
         reduction_layout.addWidget(self.average_reduction_rButton)
+        reduction_layout.addWidget(self.median_reduction_rButton)
 
         layout.addLayout(reduction_layout, 1, 0, 1, 2)
 

--- a/tofu/ez/GUI/Advanced/ffc.py
+++ b/tofu/ez/GUI/Advanced/ffc.py
@@ -61,6 +61,12 @@ class FFCGroup(QGroupBox):
         self.flat_scale_entry.setValidator(get_double_validator())
         self.flat_scale_entry.editingFinished.connect(self.set_flat_scale)
 
+        self.reduction_label = QLabel("Reduction Mode:")
+        self.median_reduction_rButton = QRadioButton("Median")
+        self.median_reduction_rButton.clicked.connect(self.set_reduction_mode)
+        self.average_reduction_rButton = QRadioButton("Average")
+        self.average_reduction_rButton.clicked.connect(self.set_reduction_mode)
+
         self.set_layout()
 
     def set_layout(self):
@@ -69,26 +75,34 @@ class FFCGroup(QGroupBox):
         layout.addWidget(self.flat_scale_label, 0, 0)
         layout.addWidget(self.flat_scale_entry, 0, 1)
 
+        reduction_layout = QHBoxLayout()
+        reduction_layout.addWidget(self.reduction_label)
+        reduction_layout.addWidget(self.median_reduction_rButton)
+        reduction_layout.addWidget(self.average_reduction_rButton)
+
+        layout.addLayout(reduction_layout, 1, 0, 1, 2)
+
         rbutton_layout = QHBoxLayout()
         rbutton_layout.addWidget(self.method_label)
         rbutton_layout.addWidget(self.eigen_rButton)
         rbutton_layout.addWidget(self.average_rButton)
         rbutton_layout.addWidget(self.ssim_rButton)
 
-        layout.addWidget(self.enable_sinFFC_checkbox, 1, 0)
-        layout.addItem(rbutton_layout, 2, 0, 1, 2)
-        layout.addWidget(self.eigen_pco_repetitions_label, 3, 0)
-        layout.addWidget(self.eigen_pco_repetitions_entry, 3, 1)
-        layout.addWidget(self.eigen_pco_downsample_label, 4, 0)
-        layout.addWidget(self.eigen_pco_downsample_entry, 4, 1)
-        layout.addWidget(self.downsample_label, 5, 0)
-        layout.addWidget(self.downsample_entry, 5, 1)
+        layout.addWidget(self.enable_sinFFC_checkbox, 2, 0)
+        layout.addItem(rbutton_layout, 3, 0, 1, 2)
+        layout.addWidget(self.eigen_pco_repetitions_label, 4, 0)
+        layout.addWidget(self.eigen_pco_repetitions_entry, 4, 1)
+        layout.addWidget(self.eigen_pco_downsample_label, 5, 0)
+        layout.addWidget(self.eigen_pco_downsample_entry, 5, 1)
+        layout.addWidget(self.downsample_label, 6, 0)
+        layout.addWidget(self.downsample_entry, 6, 1)
 
         self.setLayout(layout)
 
     def load_values(self):
         self.enable_sinFFC_checkbox.setChecked(EZVARS['flat-correction']['smart-ffc']['value'])
         self.set_method_from_params()
+        self.set_reduction_mode_from_params()
         self.eigen_pco_repetitions_entry.setText(str(EZVARS['flat-correction']['eigen-pco-reps']['value']))
         self.eigen_pco_downsample_entry.setText(str(EZVARS['flat-correction']['eigen-pco-downsample']['value']))
         self.downsample_entry.setText(str(EZVARS['flat-correction']['downsample']['value']))
@@ -147,3 +161,19 @@ class FFCGroup(QGroupBox):
             self.eigen_rButton.setChecked(False)
             self.average_rButton.setChecked(False)
             self.ssim_rButton.setChecked(True)
+
+    def set_reduction_mode(self):
+        if self.median_reduction_rButton.isChecked():
+            LOG.debug("Reduction Mode: Median")
+            EZVARS['flat-correction']['reduction-mode']['value'] = "median"
+        elif self.average_reduction_rButton.isChecked():
+            LOG.debug("Reduction Mode: Average")
+            EZVARS['flat-correction']['reduction-mode']['value'] = "average"
+
+    def set_reduction_mode_from_params(self):
+        if EZVARS['flat-correction']['reduction-mode']['value'] == "median":
+            self.median_reduction_rButton.setChecked(True)
+            self.average_reduction_rButton.setChecked(False)
+        elif EZVARS['flat-correction']['reduction-mode']['value'] == "average":
+            self.median_reduction_rButton.setChecked(False)
+            self.average_reduction_rButton.setChecked(True)

--- a/tofu/ez/Helpers/find_360_overlap.py
+++ b/tofu/ez/Helpers/find_360_overlap.py
@@ -112,14 +112,18 @@ def find_overlap():
     return dict(zip(ctdirs, olap_estimates))
 
 def make_sinos_noPR(ctset, dirflats, dirdark, dirflats2, ax_range, sin_tmp_dir):
+    reduction_func = np.median
+    if EZVARS['flat-correction']['reduction-mode']['value'] == 'average':
+        reduction_func = np.mean
+
     try:
-        row_flat = np.median(extract_row(
+        row_flat = reduction_func(extract_row(
             os.path.join(ctset, dirflats), EZVARS_aux['find360olap']['row']['value']))
     except:
         print(f"Problem loading flats in {ctset}")
         return 1
     try:
-        row_dark = np.mean(extract_row(
+        row_dark = reduction_func(extract_row(
             os.path.join(ctset, dirdark), EZVARS_aux['find360olap']['row']['value']))
     except:
         print(f"Problem loading darks in {ctset}")
@@ -136,7 +140,7 @@ def make_sinos_noPR(ctset, dirflats, dirdark, dirflats2, ax_range, sin_tmp_dir):
     tmpstr = os.path.join(ctset, dirflats2)
     if os.path.exists(tmpstr):
         try:
-            row_flat2 = np.median(extract_row(tmpstr, EZVARS_aux['find360olap']['row']['value']))
+            row_flat2 = reduction_func(extract_row(tmpstr, EZVARS_aux['find360olap']['row']['value']))
         except:
             print(f"Problem loading flats2 in {ctset}")
             return 1
@@ -243,7 +247,7 @@ def make_sinos_PR(ctset, dirflats, dirdark, dirflats2, ax_range, sin_tmp_dir):
         stitched_pr = os.path.join(EZVARS_aux['find360olap']['tmp-dir']['value'], 'stitched-pr', f"{axis:04}")
         out_pattern = os.path.join(stitched_pr, "proj-%04i.tif")
         print(f"Phase retrieval")
-        cmd = fmt_pr_cmd(*dirs, out_pattern)
+        cmd = fmt_pr_cmd(*dirs, out_pattern, reduction_mode=EZVARS['flat-correction']['reduction-mode']['value'])
         os.system(cmd)
         print(f"Generating sinogram for the target row")
         cmd = "tofu sinos"

--- a/tofu/ez/find_axis_cmd_gen.py
+++ b/tofu/ez/find_axis_cmd_gen.py
@@ -13,15 +13,15 @@ from tofu.ez.params import EZVARS
 from tofu.config import SECTIONS
 from tofu.ez.tofu_cmd_gen import check_lamino, gpu_optim
 
-def find_axis_std(ctset, tmpdir, ax_range, p_width, nviews, wh):
+def find_axis_std(ctset, tmpdir, ax_range, p_width, nviews, wh, reduction_mode="median"):
     indir = make_inpaths(ctset[0], ctset[1])
     cmd = 'tofu reco'
     if EZVARS['advanced']['more-reco-params']['value'] is True:
         cmd += check_lamino()
     elif EZVARS['advanced']['more-reco-params']['value'] is False:
         cmd += " --overall-angle 180"
-    cmd += " --darks {} --flats {} --reduction-mode median --projections {}".format(
-        indir[0], indir[1], enquote(indir[2])
+    cmd += " --darks {} --flats {} --reduction-mode {} --projections {}".format(
+        indir[0], indir[1], reduction_mode, enquote(indir[2])
     )
     cmd += " --number {}".format(nviews)
     if EZVARS['COR']['min-std-apply-pr']['value']:

--- a/tofu/ez/main.py
+++ b/tofu/ez/main.py
@@ -68,7 +68,7 @@ def get_CTdirs_list(inpath, fdt_names):
         return W.ctsets, W.lvl0
 
 
-def frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass):
+def frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass, reduction_mode="median"):
     """formats list of processing commands for a CT set"""
     # two helper variables to note that PR/FFC has been done at some step
     swiFFC = True  # FFC is always required
@@ -102,7 +102,7 @@ def frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass):
         cmds.append('echo " - Creating mask of large bad spots in flat field"')
         cmds.append(get_find_spots_cmd(EZVARS['inout']['tmp-dir']['value']))
         cmds.append('echo " - Flat-correcting and removing large spots"')
-        cmds_inpaint = get_inp_cmd(ctset, EZVARS['inout']['tmp-dir']['value'], wh[0], nviews)
+        cmds_inpaint = get_inp_cmd(ctset, EZVARS['inout']['tmp-dir']['value'], wh[0], nviews, reduction_mode=reduction_mode)
         # reset location of input data
         ctset = (EZVARS['inout']['tmp-dir']['value'], ctset[1])
         cmds.extend(cmds_inpaint)
@@ -116,10 +116,10 @@ def frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass):
         if swiFFC:  # we still need need flat correction #Inpaint No
             cmds.append('echo " - Phase retrieval with flat-correction"')
             if EZVARS['flat-correction']['smart-ffc']['value']:
-                cmds.append(get_pr_sinFFC_cmd(ctset))
+                cmds.append(get_pr_sinFFC_cmd(ctset, reduction_mode=reduction_mode))
                 cmds.append(get_pr_tofu_cmd_sinFFC(ctset))
             elif not EZVARS['flat-correction']['smart-ffc']['value']:
-                cmds.append(get_pr_tofu_cmd(ctset))
+                cmds.append(get_pr_tofu_cmd(ctset, reduction_mode=reduction_mode))
         else:  # Inpaint Yes
             cmds.append('echo " - Phase retrieval from flat-corrected projections"')
             cmds.extend(get_pr_ufo_cmd(nviews, wh))
@@ -132,14 +132,14 @@ def frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass):
         if swiFFC:  # we still need to do flat-field correction
             if EZVARS['flat-correction']['smart-ffc']['value']:
                 # Create flat corrected images using sinFFC
-                cmds.append(get_sinFFC_cmd(ctset))
+                cmds.append(get_sinFFC_cmd(ctset, reduction_mode=reduction_mode))
                 # Feed the flat corrected images to sino gram generation
                 cmds.append(get_sinos_noffc_cmd(ctset[0], EZVARS['inout']['tmp-dir']['value'],
                                                 nviews, wh, n_per_pass))
             elif not EZVARS['flat-correction']['smart-ffc']['value']:
                 cmds.append('echo " - Make sinograms with flat-correction"')
                 cmds.append(get_sinos_ffc_cmd(ctset, EZVARS['inout']['tmp-dir']['value'],
-                                              nviews, wh, n_per_pass))
+                                              nviews, wh, n_per_pass, reduction_mode=reduction_mode))
         else:  # we do not need flat-field correction
             cmds.append('echo " - Make sinograms without flat-correction"')
             cmds.append(get_sinos_noffc_cmd(ctset[0], EZVARS['inout']['tmp-dir']['value'],
@@ -184,10 +184,10 @@ def frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass):
     # Finally - call to tofu reco
     cmds.append('echo " - CT with axis {}; ffc:{}, PR:{}"'.format(ax, swiFFC, swiPR))
     if EZVARS['flat-correction']['smart-ffc']['value'] and swiFFC:
-        cmds.append(get_sinFFC_cmd(ctset))
-        cmds.append(get_reco_cmd(ctset, out_pattern, ax, nviews, wh, False, swiPR))
+        cmds.append(get_sinFFC_cmd(ctset, reduction_mode=reduction_mode))
+        cmds.append(get_reco_cmd(ctset, out_pattern, ax, nviews, wh, False, swiPR, reduction_mode=reduction_mode))
     else:  # If not using sinFFC
-        cmds.append(get_reco_cmd(ctset, out_pattern, ax, nviews, wh, swiFFC, swiPR))
+        cmds.append(get_reco_cmd(ctset, out_pattern, ax, nviews, wh, swiFFC, swiPR, reduction_mode=reduction_mode))
 
     return nviews, wh
 
@@ -202,6 +202,8 @@ def execute_reconstruction():
     if EZVARS['inout']['clip_hist']['value']:
         if SECTIONS['general']['output-minimum']['value'] > SECTIONS['general']['output-maximum']['value']:
             raise ValueError('hmin must be smaller than hmax to convert to 8bit without contrast inversion')
+
+    reduction_mode = EZVARS['flat-correction']['reduction-mode']['value']
 
     # get list of all good CT directories to be reconstructed
 
@@ -300,7 +302,7 @@ def execute_reconstruction():
                                         os.path.join(EZVARS['inout']['output-dir']['value'], setid),
                                         EZVARS['COR']['search-interval']['value'],
                                         EZVARS['COR']['patch-size']['value'],
-                                        nviews, wh)
+                                        nviews, wh, reduction_mode=reduction_mode)
                 else:
                     ax = axlist[i]#EZVARS['COR']['user-defined-ax']['value'] + i * EZVARS['COR']['user-defined-dax']['value']
             # If EZVARS['COR']['search-method']['value'] >= 4 then bypass axis search and use image midpoint
@@ -317,7 +319,7 @@ def execute_reconstruction():
             cmds.append('echo "Cleaning temporary directory"'.format(setid))
             clean_tmp_dirs(EZVARS['inout']['tmp-dir']['value'], fdt_names)
             # call function which formats commands for this data set
-            nviews, wh = frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass)
+            nviews, wh = frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass, reduction_mode=reduction_mode)
             save_params(setid, ax, nviews, wh)
             print('{}\t{}'.format('CTset:', ctset[0]))
             print('{:>30}\t{}'.format('Axis:', ax))

--- a/tofu/ez/params.py
+++ b/tofu/ez/params.py
@@ -460,7 +460,7 @@ EZVARS['flat-correction'] = {
         'type': float, 
         'help': "Scaling falt"}, #(?) has the same name in SECTION
     'reduction-mode': {
-        'ezdefault': "median",
+        'ezdefault': "average",
         'type': str,
         'help': "Reduction mode for dark/flat fields: median or average"},
 }

--- a/tofu/ez/params.py
+++ b/tofu/ez/params.py
@@ -459,6 +459,10 @@ EZVARS['flat-correction'] = {
         'ezdefault': 1.0,
         'type': float, 
         'help': "Scaling falt"}, #(?) has the same name in SECTION
+    'reduction-mode': {
+        'ezdefault': "median",
+        'type': str,
+        'help': "Reduction mode for dark/flat fields: median or average"},
 }
 
 #TODO ADD CHECKING NLMDN SETTINGS

--- a/tofu/ez/tofu_cmd_gen.py
+++ b/tofu/ez/tofu_cmd_gen.py
@@ -239,7 +239,7 @@ def get_pr_tofu_cmd_sinFFC(ctset):
     cmd += ' --projection-crop-after filter'
     return cmd
 
-def get_pr_tofu_cmd(ctset):
+def get_pr_tofu_cmd(ctset, reduction_mode="median"):
     # indir will format paths to flats darks and tomo2 correctly even if they were
     # pre-processed, however path to the input directory with projections
     # cannot be formatted with that command correctly
@@ -249,7 +249,7 @@ def get_pr_tofu_cmd(ctset):
                                                ctset[0], EZVARS['inout']['tomo-dir']['value'])
     flats2_dir = indir[3] if ctset[1] == 4 else None
 
-    return fmt_pr_cmd(indir[0], indir[1], in_proj_dir, flats2_dir, out_pattern)
+    return fmt_pr_cmd(indir[0], indir[1], in_proj_dir, flats2_dir, out_pattern, reduction_mode=reduction_mode)
 
 def fmt_pr_cmd(darks_dir, flats_dir, tomo_dir, flats2_dir, out_pattern, reduction_mode="median"):
     cmd = 'tofu preprocess --fix-nan-and-inf --projection-filter none --delta 1e-6'

--- a/tofu/ez/tofu_cmd_gen.py
+++ b/tofu/ez/tofu_cmd_gen.py
@@ -58,7 +58,7 @@ def check_bigtif(cmd, swi):
         cmd += " --output-bytes-per-file 0"
     return cmd
 
-def get_1step_ct_cmd(ctset, out_pattern, ax, nviews, wh):
+def get_1step_ct_cmd(ctset, out_pattern, ax, nviews, wh, reduction_mode="median"):
     # direct CT reconstruction from input dir to output dir;
     # obsolete, replaced by tofu reco, see get_reco_cmd() lower
     indir = make_inpaths(ctset[0], ctset[1])
@@ -68,7 +68,7 @@ def get_1step_ct_cmd(ctset, out_pattern, ax, nviews, wh):
     indir[2] = os.path.join(os.path.split(indir[2])[0], os.path.split(in_proj_dir)[1])
     # format command
     cmd = "tofu tomo --absorptivity --fix-nan-and-inf"
-    cmd += " --darks {} --flats {} --reduction-mode median --projections {}".format(indir[0], indir[1], indir[2])
+    cmd += " --darks {} --flats {} --reduction-mode {} --projections {}".format(indir[0], indir[1], reduction_mode, indir[2])
     if ctset[1] == 4:  # must be equivalent to len(indir)>3
         cmd += " --flats2 {}".format(indir[3])
     cmd += " --output {}".format(out_pattern)
@@ -131,12 +131,12 @@ def get_ct_sin_cmd(out_pattern, ax, nviews, wh):
     cmd = check_bigtif(cmd, EZVARS['inout']['bigtiff-output']['value'])
     return cmd
 
-def get_sinos_ffc_cmd(ctset, tmpdir, nviews, wh, n_per_pass):
+def get_sinos_ffc_cmd(ctset, tmpdir, nviews, wh, n_per_pass, reduction_mode="median"):
     indir = make_inpaths(ctset[0], ctset[1])
     in_proj_dir, out_pattern = fmt_in_out_path(EZVARS['inout']['tmp-dir']['value'],
                                     ctset[0], EZVARS['inout']['tomo-dir']['value'], False)
     cmd = 'tofu sinos --absorptivity --fix-nan-and-inf'
-    cmd += ' --darks {} --flats {} --reduction-mode median '.format(indir[0], indir[1])
+    cmd += ' --darks {} --flats {} --reduction-mode {} '.format(indir[0], indir[1], reduction_mode)
     if ctset[1] == 4:
         cmd += " --flats2 {}".format(indir[3])
     cmd += " --projections {}".format(in_proj_dir)
@@ -186,12 +186,12 @@ def get_sinos2proj_cmd(proj_height, n_per_pass):
     cmd += f" --pass-size {n_per_pass}"
     return cmd
 
-def get_sinFFC_cmd(ctset):
+def get_sinFFC_cmd(ctset, reduction_mode="median"):
     indir = make_inpaths(ctset[0], ctset[1])
     in_proj_dir, out_pattern = fmt_in_out_path(EZVARS['inout']['tmp-dir']['value'],
                                                ctset[0], EZVARS['inout']['tomo-dir']['value'])
     cmd = 'bmit_sin --fix-nan'
-    cmd += ' --darks {} --flats {} --reduction-mode median --projections {}'.format(indir[0], indir[1], in_proj_dir)
+    cmd += ' --darks {} --flats {} --reduction-mode {} --projections {}'.format(indir[0], indir[1], reduction_mode, in_proj_dir)
     if ctset[1] == 4:
         cmd += ' --flats2 {}'.format(indir[3])
     cmd += ' --output {}'.format(os.path.dirname(out_pattern))
@@ -202,12 +202,12 @@ def get_sinFFC_cmd(ctset):
     cmd += ' --downsample {}'.format(EZVARS['flat-correction']['downsample']['value'])
     return cmd
 
-def get_pr_sinFFC_cmd(ctset):
+def get_pr_sinFFC_cmd(ctset, reduction_mode="median"):
     indir = make_inpaths(ctset[0], ctset[1])
     in_proj_dir, out_pattern = fmt_in_out_path(
         EZVARS['inout']['tmp-dir']['value'], ctset[0], EZVARS['inout']['tomo-dir']['value'])
     cmd = 'bmit_sin --fix-nan'
-    cmd += ' --darks {} --flats {} --reduction-mode median --projections {}'.format(indir[0], indir[1], in_proj_dir)
+    cmd += ' --darks {} --flats {} --reduction-mode {} --projections {}'.format(indir[0], indir[1], reduction_mode, in_proj_dir)
     if ctset[1] == 4:
         cmd += ' --flats2 {}'.format(indir[3])
     cmd += ' --output {}'.format(os.path.dirname(out_pattern))
@@ -251,10 +251,10 @@ def get_pr_tofu_cmd(ctset):
 
     return fmt_pr_cmd(indir[0], indir[1], in_proj_dir, flats2_dir, out_pattern)
 
-def fmt_pr_cmd(darks_dir, flats_dir, tomo_dir, flats2_dir, out_pattern):
+def fmt_pr_cmd(darks_dir, flats_dir, tomo_dir, flats2_dir, out_pattern, reduction_mode="median"):
     cmd = 'tofu preprocess --fix-nan-and-inf --projection-filter none --delta 1e-6'
-    cmd += ' --darks {} --flats {} --reduction-mode median --projections {}'.\
-                format(darks_dir, flats_dir, tomo_dir)
+    cmd += ' --darks {} --flats {} --reduction-mode {} --projections {}'.\
+                format(darks_dir, flats_dir, reduction_mode, tomo_dir)
     if flats2_dir:
         cmd += ' --flats2 {}'.format(flats2_dir)
     cmd += ' --output {}'.format(out_pattern)
@@ -267,7 +267,7 @@ def fmt_pr_cmd(darks_dir, flats_dir, tomo_dir, flats2_dir, out_pattern):
     cmd += ' --flat-scale {}'.format(EZVARS['flat-correction']['flat-scale']['value'])
     return cmd
 
-def get_reco_cmd(ctset, out_pattern, ax, nviews, wh, ffc, pr):
+def get_reco_cmd(ctset, out_pattern, ax, nviews, wh, ffc, pr, reduction_mode="median"):
     # direct CT reconstruction from input dir to output dir;
     # or CT reconstruction after preprocessing only
     indir = make_inpaths(ctset[0], ctset[1])
@@ -285,7 +285,7 @@ def get_reco_cmd(ctset, out_pattern, ax, nviews, wh, ffc, pr):
     cmd += ' --output {}'.format(out_pattern)
     if ffc:
         cmd += ' --fix-nan-and-inf'
-        cmd += ' --darks {} --flats {} --reduction-mode median'.format(indir[0], indir[1])
+        cmd += ' --darks {} --flats {} --reduction-mode {}'.format(indir[0], indir[1], reduction_mode)
         if ctset[1] == 4:  # must be equivalent to len(indir)>3
             cmd += ' --flats2 {}'.format(indir[3])
         if not pr:

--- a/tofu/ez/ufo_cmd_gen.py
+++ b/tofu/ez/ufo_cmd_gen.py
@@ -115,7 +115,7 @@ def get_pre_cmd( ctset, pre_cmd, tmpdir):
         cmds[i] += " ! write filename={}".format(enquote(out_pattern))
     return cmds
 
-def get_inp_cmd(ctset, tmpdir, N, nviews):
+def get_inp_cmd(ctset, tmpdir, N, nviews, reduction_mode="median"):
     indir = make_inpaths(ctset[0], ctset[1])
     cmds = []
     # ######### CREATE MASK #########
@@ -154,7 +154,7 @@ def get_inp_cmd(ctset, tmpdir, N, nviews):
         cmds.append(cmd)
     elif not EZVARS['flat-correction']['smart-ffc']['value']:
         cmd = 'tofu flatcorrect --fix-nan-and-inf'
-        cmd += ' --darks {} --flats {} --reduction-mode median'.format(indir[0], indir[1])
+        cmd += ' --darks {} --flats {} --reduction-mode {}'.format(indir[0], indir[1], reduction_mode)
         cmd += ' --projections {}'.format(in_proj_dir)
         cmd += ' --output {}'.format(out_pattern)
         if ctset[1] == 4:


### PR DESCRIPTION
@sgasilov wrote:

> there is one thing that has to be undone - flats-mode median must be removed from all frmt_tofu_cmds. I did it back in 2023 for the sake of having a somewhat cleaner reconstruction of data corrupted by plenty of hot spots (e.g. wiggler at high magnetic field) without using remove outliers. I thought it is a harmless change, however, I now have examples of data where median flat emphasizes the rings. It is better to stick to the default mean flat.

Here is what we are testing now for the issue you describe. 

Edit: I *did* change the ez default.