### PR TITLE
Port Qt imports to pyqtgraph abstraction layer for PyQt5/PyQt6 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,10 @@ Homepage = "http://github.com/ufo-kit/tofu"
 
 [project.optional-dependencies]
 interactive = ["IPython"]
-gui = ["PyQt5", "pyqtgraph"]
-flow = ["PyQt5", "networkx", "pyqtconsole", "pyxdg", "qtpynodeeditor", "pyqtgraph"]
+gui = ["pyqtgraph"]
+flow = ["networkx", "pyqtconsole", "pyxdg", "qtpynodeeditor", "pyqtgraph"]
 test = ["pytest", "pytest-qt"]
-ez = ["PyQt5", "PyYAML", "pyqtgraph", "matplotlib"]
+ez = ["PyYAML", "pyqtgraph", "matplotlib"]
 edf = ["fabio"]
 
 [tool.setuptools]

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,10 @@ setup(
     ],
     extras_require={
         'interactive': ['IPython'],
-        'gui': ['PyQt5', 'pyqtgraph'],
-        'flow': ['PyQt5', 'networkx', 'pyqtconsole', 'pyxdg', 'qtpynodeeditor', 'pyqtgraph'],
+        'gui': ['pyqtgraph'],
+        'flow': ['networkx', 'pyqtconsole', 'pyxdg', 'qtpynodeeditor', 'pyqtgraph'],
         'test': ['pytest', 'pytest-qt'],
-        'ez': ['PyQt5', 'PyYAML', 'pyqtgraph', 'matplotlib'],
+        'ez': ['PyYAML', 'pyqtgraph', 'matplotlib'],
         'edf': ['fabio'],
     },
     description="A fast, versatile and user-friendly image "\

--- a/tofu/ez/GUI/Advanced/Batch360.py
+++ b/tofu/ez/GUI/Advanced/Batch360.py
@@ -1,7 +1,7 @@
 import logging
-from PyQt5.QtWidgets import (QGridLayout, QLabel, QGroupBox, QLineEdit, QRadioButton, QPushButton,
+from pyqtgraph.Qt.QtWidgets import (QGridLayout, QLabel, QGroupBox, QLineEdit, QRadioButton, QPushButton,
     QFileDialog, QMessageBox,QCheckBox)
-from PyQt5.QtCore import pyqtSignal
+from pyqtgraph.Qt.QtCore import pyqtSignal
 from tofu.ez.params import EZVARS_aux
 from tofu.ez.util import add_value_to_dict_entry, import_values
 import os

--- a/tofu/ez/GUI/Advanced/Batch360.py
+++ b/tofu/ez/GUI/Advanced/Batch360.py
@@ -137,8 +137,8 @@ class Batch360Group(QGroupBox):
             qm = QMessageBox()
             rep = qm.question(self, 'WARNING', "Directory exists and not empty. \n "
                                                "Clean it or select a new directory. \n"
-                                               "Is it SAFE to delete directory now?", qm.Yes | qm.No)
-            if rep == qm.Yes:
+                                               "Is it SAFE to delete directory now?", qm.StandardButton.Yes | qm.StandardButton.No)
+            if rep == qm.StandardButton.Yes:
                 try:
                     rmtree(tmp_dir)
                 except:
@@ -167,7 +167,7 @@ class Batch360Group(QGroupBox):
         Loads external settings from .yaml file specified by user
         Signal is sent to enable updating of displayed GUI values
         """
-        options = QFileDialog.Options()
+        options = QFileDialog.Option.DontUseNativeDialog
         filePath, _ = QFileDialog.getOpenFileName(
             self,
             "QFileDialog.getOpenFileName()",

--- a/tofu/ez/GUI/Advanced/advanced.py
+++ b/tofu/ez/GUI/Advanced/advanced.py
@@ -1,5 +1,5 @@
 import logging
-from PyQt5.QtWidgets import QGridLayout, QLabel, QGroupBox, QLineEdit
+from pyqtgraph.Qt.QtWidgets import QGridLayout, QLabel, QGroupBox, QLineEdit
 from tofu.ez.params import EZVARS
 from tofu.config import SECTIONS
 from tofu.ez.util import add_value_to_dict_entry, get_double_validator, reverse_tupleize

--- a/tofu/ez/GUI/Advanced/ffc.py
+++ b/tofu/ez/GUI/Advanced/ffc.py
@@ -1,5 +1,5 @@
 import logging
-from PyQt5.QtWidgets import (
+from pyqtgraph.Qt.QtWidgets import (
     QGridLayout,
     QLabel,
     QGroupBox,

--- a/tofu/ez/GUI/Advanced/find_large_spots.py
+++ b/tofu/ez/GUI/Advanced/find_large_spots.py
@@ -1,5 +1,5 @@
 import logging
-from PyQt5.QtWidgets import (
+from pyqtgraph.Qt.QtWidgets import (
     QGridLayout,
     QLabel,
     QGroupBox,

--- a/tofu/ez/GUI/Advanced/nlmdn.py
+++ b/tofu/ez/GUI/Advanced/nlmdn.py
@@ -189,7 +189,7 @@ class NLMDNGroup(QGroupBox):
 
     def select_image(self):
         LOG.debug("Select one image button pressed")
-        options = QFileDialog.Options()
+        options = QFileDialog.Option.DontUseNativeDialog
         file_path, _ = QFileDialog.getOpenFileName(
             self, "Open .tif Image File", "", "Tiff Files (*.tif *.tiff)", options=options
         )
@@ -280,9 +280,9 @@ class NLMDNGroup(QGroupBox):
         """
         LOG.debug("DELETE")
         msg = "Delete directory with reconstructed data?"
-        dialog = QMessageBox.warning(self, "Warning: data can be lost", msg, QMessageBox.Yes | QMessageBox.No)
+        dialog = QMessageBox.warning(self, "Warning: data can be lost", msg, QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
 
-        if dialog == QMessageBox.Yes:
+        if dialog == QMessageBox.StandardButton.Yes:
             if os.path.exists(str(EZVARS['nlmdn']['output_pattern']['value'])):
                 LOG.debug("YES")
                 if EZVARS['nlmdn']['output_pattern']['value'] == EZVARS['nlmdn']['input-dir']['value']:
@@ -309,8 +309,8 @@ class NLMDNGroup(QGroupBox):
                 EZVARS['nlmdn']['dryrun']['value']:
             title_text = "Warning: files can be overwritten"
             text1 = "Output directory exists. Files can be overwritten. Proceed?"
-            dialog = QMessageBox.warning(self, title_text, text1, QMessageBox.Yes | QMessageBox.No)
-            if dialog == QMessageBox.Yes:
+            dialog = QMessageBox.warning(self, title_text, text1, QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
+            if dialog == QMessageBox.StandardButton.Yes:
                 cmd = fmt_nlmdn_ufo_cmd(EZVARS['nlmdn']['input-dir']['value'],
                                         EZVARS['nlmdn']['output_pattern']['value'])
         else:

--- a/tofu/ez/GUI/Advanced/nlmdn.py
+++ b/tofu/ez/GUI/Advanced/nlmdn.py
@@ -2,7 +2,7 @@ import logging
 import os
 from shutil import rmtree
 
-from PyQt5.QtWidgets import (
+from pyqtgraph.Qt.QtWidgets import (
     QGridLayout,
     QLabel,
     QGroupBox,
@@ -12,7 +12,7 @@ from PyQt5.QtWidgets import (
     QFileDialog,
     QMessageBox,
 )
-from PyQt5.QtCore import Qt
+from pyqtgraph.Qt.QtCore import Qt
 from tofu.ez.ufo_cmd_gen import fmt_nlmdn_ufo_cmd
 from tofu.ez.params import EZVARS
 from tofu.ez.util import add_value_to_dict_entry, get_int_validator, get_double_validator
@@ -105,7 +105,7 @@ class NLMDNGroup(QGroupBox):
         layout.addWidget(self.select_img_button, 1, 2, 1, 2)
         layout.addWidget(self.input_dir_entry, 2, 0, 1, 4)
         layout.addWidget(self.output_dir_button, 3, 0, 1, 2)
-        layout.addWidget(self.save_bigtif_checkbox, 3, 2, 1, 2, Qt.AlignCenter)
+        layout.addWidget(self.save_bigtif_checkbox, 3, 2, 1, 2, Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self.output_dir_entry, 4, 0, 1, 4)
         layout.addWidget(self.similarity_radius_label, 5, 0, 1, 2)
         layout.addWidget(self.similarity_radius_entry, 5, 2, 1, 2)
@@ -117,8 +117,8 @@ class NLMDNGroup(QGroupBox):
         layout.addWidget(self.noise_std_entry, 8, 2, 1, 2)
         layout.addWidget(self.window_label, 9, 0, 1, 2)
         layout.addWidget(self.window_entry, 9, 2, 1, 2)
-        layout.addWidget(self.fast_checkbox, 10, 0, 1, 2, Qt.AlignCenter)
-        layout.addWidget(self.sigma_checkbox, 10, 2, 1, 2, Qt.AlignCenter)
+        layout.addWidget(self.fast_checkbox, 10, 0, 1, 2, Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.sigma_checkbox, 10, 2, 1, 2, Qt.AlignmentFlag.AlignCenter)
 
         layout.addWidget(self.help_button, 11, 0, 1, 1)
         layout.addWidget(self.delete_button, 11, 1)

--- a/tofu/ez/GUI/Advanced/optimization.py
+++ b/tofu/ez/GUI/Advanced/optimization.py
@@ -1,5 +1,5 @@
 import logging
-from PyQt5.QtWidgets import QGridLayout, QLabel, QGroupBox, QLineEdit, QCheckBox, QComboBox
+from pyqtgraph.Qt.QtWidgets import QGridLayout, QLabel, QGroupBox, QLineEdit, QCheckBox, QComboBox
 
 from tofu.ez.params import EZVARS
 from tofu.config import SECTIONS

--- a/tofu/ez/GUI/Main/centre_of_rotation.py
+++ b/tofu/ez/GUI/Main/centre_of_rotation.py
@@ -1,7 +1,7 @@
 import logging
-from PyQt5.QtWidgets import (QGridLayout, QLabel, QRadioButton,
+from pyqtgraph.Qt.QtWidgets import (QGridLayout, QLabel, QRadioButton,
             QGroupBox, QLineEdit, QCheckBox, QMessageBox)
-from PyQt5.QtCore import pyqtSignal
+from pyqtgraph.Qt.QtCore import pyqtSignal
 from tofu.ez.params import EZVARS
 from tofu.ez.util import (add_value_to_dict_entry,
                           get_int_validator, get_tuple_validator,

--- a/tofu/ez/GUI/Main/config.py
+++ b/tofu/ez/GUI/Main/config.py
@@ -459,24 +459,9 @@ class ConfigGroup(QGroupBox):
 
     def quit_button_pressed(self):
         """
-        Displays confirmation dialog and cleans temporary directories
+        Triggers application close which handles confirmation and cleanup
         """
-        LOG.debug("QUIT")
-        reply = QMessageBox.question(
-            self,
-            "Quit",
-            "Are you sure you want to quit?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
-        )
-        if reply == QMessageBox.Yes:
-            # remove all directories with projections
-            clean_tmp_dirs(EZVARS['inout']['tmp-dir']['value'], get_fdt_names())
-            # remove axis-search dir too
-            tmp = os.path.join(EZVARS['inout']['tmp-dir']['value'], 'axis-search')
-            QCoreApplication.instance().quit()
-        else:
-            pass
+        self.window().close()
 
     def help_button_pressed(self):
         """
@@ -517,10 +502,10 @@ class ConfigGroup(QGroupBox):
         LOG.debug("DELETE")
         msg = "Delete directory with reconstructed data?"
         dialog = QMessageBox.warning(
-            self, "Warning: data can be lost", msg, QMessageBox.Yes | QMessageBox.No
+            self, "Warning: data can be lost", msg, QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
         )
 
-        if dialog == QMessageBox.Yes:
+        if dialog == QMessageBox.StandardButton.Yes:
             if os.path.exists(str(EZVARS['inout']['output-dir']['value'])):
                 LOG.debug("YES")
                 if EZVARS['inout']['output-dir']['value'] == EZVARS['inout']['input-dir']['value']:
@@ -556,7 +541,7 @@ class ConfigGroup(QGroupBox):
         to an external .yaml file specified by user
         """
         LOG.debug("Save settings pressed")
-        options = QFileDialog.Options()
+        options = QFileDialog.Option.DontUseNativeDialog
         fileName, _ = QFileDialog.getSaveFileName(
             self,
             "QFileDialog.getSaveFileName()",
@@ -579,7 +564,7 @@ class ConfigGroup(QGroupBox):
         Signal is sent to enable updating of displayed GUI values
         """
         LOG.debug("Import settings pressed")
-        options = QFileDialog.Options()
+        options = QFileDialog.Option.DontUseNativeDialog
         filePath, _ = QFileDialog.getOpenFileName(
             self,
             "QFileDialog.getOpenFileName()",

--- a/tofu/ez/GUI/Main/config.py
+++ b/tofu/ez/GUI/Main/config.py
@@ -2,7 +2,7 @@ import os
 import logging
 from functools import partial
 from shutil import rmtree
-from PyQt5.QtWidgets import (
+from pyqtgraph.Qt.QtWidgets import (
     QMessageBox,
     QFileDialog,
     QCheckBox,
@@ -12,7 +12,7 @@ from PyQt5.QtWidgets import (
     QGroupBox,
     QLineEdit,
 )
-from PyQt5.QtCore import QCoreApplication, QTimer, pyqtSignal, Qt
+from pyqtgraph.Qt.QtCore import QCoreApplication, QTimer, pyqtSignal, Qt
 
 from tofu.ez.GUI.verify_delete import verify_safe2delete
 from tofu.ez.main import execute_reconstruction, clean_tmp_dirs
@@ -249,7 +249,7 @@ class ConfigGroup(QGroupBox):
         fdt_layout.addWidget(self.select_flats2_button, 1, 4)
         fdt_layout.addWidget(self.darks_absolute_entry, 2, 1)
         fdt_layout.addWidget(self.flats_absolute_entry, 2, 2)
-        fdt_layout.addWidget(self.use_flats2_checkbox, 2, 3, Qt.AlignRight)
+        fdt_layout.addWidget(self.use_flats2_checkbox, 2, 3, Qt.AlignmentFlag.AlignRight)
         fdt_layout.addWidget(self.flats2_absolute_entry, 2, 4)
         fdt_groupbox.setLayout(fdt_layout)
         layout.addWidget(fdt_groupbox, 4, 0, 1, 5)

--- a/tofu/ez/GUI/Main/filters.py
+++ b/tofu/ez/GUI/Main/filters.py
@@ -1,5 +1,5 @@
 import logging
-from PyQt5.QtWidgets import (
+from pyqtgraph.Qt.QtWidgets import (
     QButtonGroup,
     QGridLayout,
     QLabel,
@@ -8,11 +8,11 @@ from PyQt5.QtWidgets import (
     QGroupBox,
     QLineEdit,
 )
-from PyQt5.QtCore import Qt
+from pyqtgraph.Qt.QtCore import Qt
 from tofu.ez.params import EZVARS
 from tofu.config import SECTIONS
 from tofu.ez.util import add_value_to_dict_entry, get_int_validator, get_double_validator
-from PyQt5.QtCore import pyqtSignal
+from pyqtgraph.Qt.QtCore import pyqtSignal
 
 LOG = logging.getLogger(__name__)
 
@@ -168,15 +168,15 @@ class FiltersGroup(QGroupBox):
         rr_layout.addWidget(self.use_LPF_rButton, 4, 0)
         rr_layout.addWidget(self.one_dimens_rButton, 4, 1)
         rr_layout.addWidget(self.two_dimens_rButton, 4, 2)
-        rr_layout.addWidget(self.sigma_horizontal_label, 4, 3, Qt.AlignRight)
+        rr_layout.addWidget(self.sigma_horizontal_label, 4, 3, Qt.AlignmentFlag.AlignRight)
         rr_layout.addWidget(self.sigma_horizontal_entry, 4, 4)
-        rr_layout.addWidget(self.sigma_vertical_label, 4, 5, Qt.AlignRight)
+        rr_layout.addWidget(self.sigma_vertical_label, 4, 5, Qt.AlignmentFlag.AlignRight)
         rr_layout.addWidget(self.sigma_vertical_entry, 4, 6)
         rr_layout.addWidget(self.sarepy_rButton, 5, 0)
         rr_layout.addWidget(self.wind_size_label, 5, 1)
         rr_layout.addWidget(self.wind_size_entry, 5, 2)
         rr_layout.addWidget(self.remove_wide_checkbox, 5, 3)
-        rr_layout.addWidget(self.remove_wide_label, 5, 4, Qt.AlignRight)
+        rr_layout.addWidget(self.remove_wide_label, 5, 4, Qt.AlignmentFlag.AlignRight)
         rr_layout.addWidget(self.remove_wide_entry, 5, 5)
         rr_layout.addWidget(self.SNR_label, 5, 6)
         rr_layout.addWidget(self.SNR_entry, 5, 7)

--- a/tofu/ez/GUI/Main/phase_retrieval.py
+++ b/tofu/ez/GUI/Main/phase_retrieval.py
@@ -1,6 +1,6 @@
 import logging
 import math
-from PyQt5.QtWidgets import QGridLayout, QLabel, QGroupBox, QLineEdit, QCheckBox
+from pyqtgraph.Qt.QtWidgets import QGridLayout, QLabel, QGroupBox, QLineEdit, QCheckBox
 from tofu.config import SECTIONS
 from tofu.ez.params import EZVARS
 from tofu.ez.util import add_value_to_dict_entry, reverse_tupleize, get_double_validator, get_tuple_validator

--- a/tofu/ez/GUI/Main/region_and_histogram.py
+++ b/tofu/ez/GUI/Main/region_and_histogram.py
@@ -1,6 +1,6 @@
 import logging
-from PyQt5.QtWidgets import QGridLayout, QRadioButton, QLabel, QGroupBox, QLineEdit, QCheckBox
-from PyQt5.QtCore import Qt
+from pyqtgraph.Qt.QtWidgets import QGridLayout, QRadioButton, QLabel, QGroupBox, QLineEdit, QCheckBox
+from pyqtgraph.Qt.QtCore import Qt
 
 from tofu.ez.params import EZVARS
 from tofu.config import SECTIONS

--- a/tofu/ez/GUI/Stitch_tools_tab/ez_360_multi_stitch_qt.py
+++ b/tofu/ez/GUI/Stitch_tools_tab/ez_360_multi_stitch_qt.py
@@ -362,11 +362,11 @@ class MultiStitch360Group(QGroupBox):
     def delete_button_pressed(self):
         LOG.debug("Delete button pressed")
         qm = QMessageBox()
-        rep = qm.question(self, '', "Is it safe to delete the output directory?", qm.Yes | qm.No)
+        rep = qm.question(self, '', "Is it safe to delete the output directory?", qm.StandardButton.Yes | qm.StandardButton.No)
         
         if not os.path.exists(EZVARS_aux['stitch360']['output-dir']['value']):
             warning_message("Output directory does not exist")
-        elif rep == qm.Yes:
+        elif rep == qm.StandardButton.Yes:
             print("---- Deleting Data From Output Directory ----")
             try:
                 rmtree(EZVARS_aux['stitch360']['output-dir']['value'])

--- a/tofu/ez/GUI/Stitch_tools_tab/ez_360_multi_stitch_qt.py
+++ b/tofu/ez/GUI/Stitch_tools_tab/ez_360_multi_stitch_qt.py
@@ -1,6 +1,6 @@
 from functools import partial
 
-from PyQt5.QtWidgets import (
+from pyqtgraph.Qt.QtWidgets import (
     QGroupBox,
     QPushButton,
     QCheckBox,
@@ -11,7 +11,7 @@ from PyQt5.QtWidgets import (
     QMessageBox,
     QRadioButton
 )
-from PyQt5.QtCore import pyqtSignal
+from pyqtgraph.Qt.QtCore import pyqtSignal
 import logging
 from shutil import rmtree
 import os

--- a/tofu/ez/GUI/Stitch_tools_tab/ez_360_overlap_qt.py
+++ b/tofu/ez/GUI/Stitch_tools_tab/ez_360_overlap_qt.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import (
+from pyqtgraph.Qt.QtWidgets import (
     QGroupBox,
     QPushButton,
     QCheckBox,
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import (
     QFileDialog,
     QMessageBox,
 )
-from PyQt5.QtCore import pyqtSignal
+from pyqtgraph.Qt.QtCore import pyqtSignal
 import logging
 from shutil import rmtree
 import os

--- a/tofu/ez/GUI/Stitch_tools_tab/ez_360_overlap_qt.py
+++ b/tofu/ez/GUI/Stitch_tools_tab/ez_360_overlap_qt.py
@@ -227,8 +227,8 @@ class Overlap360Group(QGroupBox):
             qm = QMessageBox()
             rep = qm.question(self, 'WARNING',
                               "Output directory exists and not empty. Is it SAFE to delete it?",
-                              qm.Yes | qm.No)
-            if rep == qm.Yes:
+                              qm.StandardButton.Yes | qm.StandardButton.No)
+            if rep == qm.StandardButton.Yes:
                 try:
                     rmtree(EZVARS_aux['find360olap']['output-dir']['value'])
                 except:
@@ -239,8 +239,8 @@ class Overlap360Group(QGroupBox):
         if os.path.exists(EZVARS_aux['find360olap']['tmp-dir']['value']) and \
                 len(os.listdir(EZVARS_aux['find360olap']['tmp-dir']['value'])) > 0:
             qm = QMessageBox()
-            rep = qm.question(self, 'WARNING', "Temporary dir exist and not empty. Is it SAFE to delete it?", qm.Yes | qm.No)
-            if rep == qm.Yes:
+            rep = qm.question(self, 'WARNING', "Temporary dir exist and not empty. Is it SAFE to delete it?", qm.StandardButton.Yes | qm.StandardButton.No)
+            if rep == qm.StandardButton.Yes:
                 try:
                     rmtree(EZVARS_aux['find360olap']['tmp-dir']['value'])
                 except:

--- a/tofu/ez/GUI/Stitch_tools_tab/ezmview_qt.py
+++ b/tofu/ez/GUI/Stitch_tools_tab/ezmview_qt.py
@@ -1,6 +1,6 @@
 import os
 import logging
-from PyQt5.QtWidgets import (
+from pyqtgraph.Qt.QtWidgets import (
     QGroupBox,
     QPushButton,
     QLineEdit,

--- a/tofu/ez/GUI/Stitch_tools_tab/ezstitch_qt.py
+++ b/tofu/ez/GUI/Stitch_tools_tab/ezstitch_qt.py
@@ -1,5 +1,5 @@
 import os
-from PyQt5.QtWidgets import (
+from pyqtgraph.Qt.QtWidgets import (
     QGroupBox,
     QPushButton,
     QCheckBox,

--- a/tofu/ez/GUI/Stitch_tools_tab/ezstitch_qt.py
+++ b/tofu/ez/GUI/Stitch_tools_tab/ezstitch_qt.py
@@ -516,8 +516,8 @@ class EZStitchGroup(QGroupBox):
         if os.path.exists(EZVARS_aux['vert-sti']['output-dir']['value']):
             qm = QMessageBox()
             rep = qm.question(self, '', f"{EZVARS_aux['vert-sti']['output-dir']['value']} \n"
-                                        "will be removed. Continue?", qm.Yes | qm.No)
-            if rep == qm.Yes:
+                                        "will be removed. Continue?", qm.StandardButton.Yes | qm.StandardButton.No)
+            if rep == qm.StandardButton.Yes:
                 try:
                     rmtree(EZVARS_aux['vert-sti']['output-dir']['value'])
                 except:

--- a/tofu/ez/GUI/ezufo_launcher.py
+++ b/tofu/ez/GUI/ezufo_launcher.py
@@ -3,7 +3,8 @@ import os
 import sys
 
 try:
-    from PyQt5 import QtWidgets as qtw
+    from pyqtgraph.Qt import QtWidgets as qtw
+    from pyqtgraph.Qt.QtGui import QAction
 except ModuleNotFoundError:
     raise ModuleNotFoundError("Cannot import modules for ez, please install tofu with [ez] extras.")
 
@@ -163,7 +164,7 @@ class GUI(qtw.QWidget):
         # )
 
 
-        finish = qtw.QAction("Quit", self)
+        finish = QAction("Quit", self)
         finish.triggered.connect(self.closeEvent)
 
         self.show()
@@ -291,7 +292,7 @@ class GUI(qtw.QWidget):
 
     def login(self):
         login_dialog = Login(self.login_parameters)
-        if login_dialog.exec_() != qtw.QDialog.Accepted:
+        if login_dialog.exec() != qtw.QDialog.Accepted:
             self.exit()
         else:
             #self.file_writer_group.root_dir_entry.setText(self.login_parameters['expdir'])
@@ -321,7 +322,7 @@ class GUI(qtw.QWidget):
 def main_qt(args=None):
     app = qtw.QApplication(sys.argv)
     window = GUI()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == "__main__":

--- a/tofu/ez/GUI/ezufo_launcher.py
+++ b/tofu/ez/GUI/ezufo_launcher.py
@@ -280,8 +280,8 @@ class GUI(qtw.QWidget):
         """
         logging.debug("QUIT")
         reply = qtw.QMessageBox.question(self, 'Quit', 'Are you sure you want to quit?',
-                        qtw.QMessageBox.Yes | qtw.QMessageBox.No, qtw.QMessageBox.No)
-        if reply == qtw.QMessageBox.Yes:
+                        qtw.QMessageBox.StandardButton.Yes | qtw.QMessageBox.StandardButton.No, qtw.QMessageBox.StandardButton.No)
+        if reply == qtw.QMessageBox.StandardButton.Yes:
             # remove all directories with projections
             clean_tmp_dirs(EZVARS['inout']['tmp-dir']['value'], get_fdt_names())
             # remove axis-search dir too

--- a/tofu/ez/GUI/image_viewer.py
+++ b/tofu/ez/GUI/image_viewer.py
@@ -3,7 +3,7 @@ import logging
 import pyqtgraph as pg
 import numpy as np
 import tifffile
-from PyQt5.QtWidgets import (
+from pyqtgraph.Qt.QtWidgets import (
     QPushButton,
     QGroupBox,
     QLabel,
@@ -15,7 +15,7 @@ from PyQt5.QtWidgets import (
     QFileDialog,
     QMessageBox,
 )
-from PyQt5.QtCore import Qt
+from pyqtgraph.Qt.QtCore import Qt
 import tofu.ez.image_read_write as image_read_write
 
 #TODO Integrate axis search tab ob tofu gui into this interface
@@ -74,9 +74,9 @@ class ImageViewerGroup(QGroupBox):
         self.save_32bit_rButton.setChecked(True)
 
         self.hist_min_label = QLabel("Histogram Min:")
-        self.hist_min_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        self.hist_min_label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
         self.hist_max_label = QLabel("Histogram Max:")
-        self.hist_max_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        self.hist_max_label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
 
         self.hist_min_input = QDoubleSpinBox()
         self.hist_min_input.setDecimals(12)
@@ -95,7 +95,7 @@ class ImageViewerGroup(QGroupBox):
         self.image_window.ui.histogram.gradient.hide()
         self.histo = self.image_window.getHistogramWidget()
 
-        self.scroller = QScrollBar(Qt.Horizontal)
+        self.scroller = QScrollBar(Qt.Orientation.Horizontal)
         self.scroller.orientation()
         self.scroller.setEnabled(False)
         self.scroller.valueChanged.connect(self.scroll_changed)

--- a/tofu/ez/GUI/image_viewer.py
+++ b/tofu/ez/GUI/image_viewer.py
@@ -146,7 +146,7 @@ class ImageViewerGroup(QGroupBox):
         :return: None
         """
         LOG.debug("Open image button pressed")
-        options = QFileDialog.Options()
+        options = QFileDialog.Option.DontUseNativeDialog
         filePath, _ = QFileDialog.getOpenFileName(
             self, "Open .tif Image File", "", "Tiff Files (*.tif *.tiff)", options=options
         )
@@ -175,7 +175,7 @@ class ImageViewerGroup(QGroupBox):
         :return: None
         """
         LOG.debug("Save image to file")
-        options = QFileDialog.Options()
+        options = QFileDialog.Option.DontUseNativeDialog
         filepath, _ = QFileDialog.getSaveFileName(
             self, "QFileDialog.getSaveFileName()", "", "Tiff Files (*.tif *.tiff)", options=options
         )
@@ -207,7 +207,7 @@ class ImageViewerGroup(QGroupBox):
             try:
                 tiff_list = (".tif", ".tiff")
                 msg = QMessageBox()
-                msg.setIcon(QMessageBox.Information)
+                msg.setIcon(QMessageBox.Icon.Information)
                 msg.setWindowTitle("Loading Images...")
                 msg.setText("Loading Images from Directory")
                 msg.show()
@@ -230,7 +230,7 @@ class ImageViewerGroup(QGroupBox):
         try:
             tiff_list = (".tif", ".tiff")
             msg = QMessageBox()
-            msg.setIcon(QMessageBox.Information)
+            msg.setIcon(QMessageBox.Icon.Information)
             msg.setWindowTitle("Loading Images...")
             msg.setText("Loading Images from Directory")
             msg.show()
@@ -257,7 +257,7 @@ class ImageViewerGroup(QGroupBox):
         if directory:
             bit_depth_string = self.check_bit_depth(self.bit_depth)
             msg = QMessageBox()
-            msg.setIcon(QMessageBox.Information)
+            msg.setIcon(QMessageBox.Icon.Information)
             msg.setWindowTitle("Saving Images...")
             msg.setText("Saving Images to Directory")
             msg.show()
@@ -271,14 +271,14 @@ class ImageViewerGroup(QGroupBox):
         :return: None
         """
         LOG.debug("Open big tiff button pressed")
-        options = QFileDialog.Options()
+        options = QFileDialog.Option.DontUseNativeDialog
         filePath, _ = QFileDialog.getOpenFileName(
             self, "QFileDialog.getOpenFileName()", "", "All Files (*)", options=options
         )
         if filePath:
             LOG.debug("Import image path: " + filePath)
             msg = QMessageBox()
-            msg.setIcon(QMessageBox.Information)
+            msg.setIcon(QMessageBox.Icon.Information)
             msg.setWindowTitle("Loading Images...")
             msg.setText("Loading Images from BigTiff")
             msg.show()
@@ -298,13 +298,13 @@ class ImageViewerGroup(QGroupBox):
         LOG.debug("Save stack to bigtiff button pressed")
         LOG.debug("Saving with bitdepth: " + str(self.bit_depth))
         dir_explore = QFileDialog()
-        options = QFileDialog.Options()
+        options = QFileDialog.Option.DontUseNativeDialog
         filepath, _ = QFileDialog.getSaveFileName(
             self, "QFileDialog.getSaveFileName()", "", "Tiff Files (*.tif *.tiff)", options=options
         )
         if filepath:
             msg = QMessageBox()
-            msg.setIcon(QMessageBox.Information)
+            msg.setIcon(QMessageBox.Icon.Information)
             msg.setWindowTitle("Saving Images...")
             msg.setText("Saving Images to BigTiff")
             msg.show()

--- a/tofu/ez/GUI/login_dialog.py
+++ b/tofu/ez/GUI/login_dialog.py
@@ -1,7 +1,7 @@
 import re
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import (
+from pyqtgraph.Qt.QtCore import Qt
+from pyqtgraph.Qt.QtWidgets import (
     QDialog,
     QLineEdit,
     QPushButton,
@@ -21,8 +21,8 @@ class Login(QDialog):
         self.login_parameters_dict = login_parameters_dict
 
         self.setWindowTitle("USER LOGIN")
-        self.setWindowModality(Qt.ApplicationModal)
-        self.setAttribute(Qt.WA_DeleteOnClose)
+        self.setWindowModality(Qt.WindowModality.ApplicationModal)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
 
         self.welcome_label = QLabel()
         self.welcome_label.setText("Welcome to BMIT!")
@@ -49,9 +49,9 @@ class Login(QDialog):
 
     def set_layout(self):
         layout = QGridLayout()
-        self.welcome_label.setAlignment(Qt.AlignCenter)
-        self.prompt_label_bl.setAlignment(Qt.AlignCenter)
-        self.prompt_label_expdir.setAlignment(Qt.AlignCenter)
+        self.welcome_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.prompt_label_bl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.prompt_label_expdir.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self.welcome_label, 0, 0, 1, 2)
         layout.addWidget(self.prompt_label_bl, 1, 0, 1, 2)
         layout.addWidget(self.bl_label, 2, 0, 1, 1)

--- a/tofu/ez/GUI/login_dialog.py
+++ b/tofu/ez/GUI/login_dialog.py
@@ -68,8 +68,7 @@ class Login(QDialog):
         self.setLayout(layout)
 
     def select_expdir_func(self):
-        options = QFileDialog.Options()
-        options |= QFileDialog.DontUseNativeDialog
+        options = QFileDialog.Option.DontUseNativeDialog
         root_dir = QFileDialog.getExistingDirectory(
             self, "Select working directory", "/data/gui-test", options=options
         )

--- a/tofu/ez/GUI/message_dialog.py
+++ b/tofu/ez/GUI/message_dialog.py
@@ -1,11 +1,11 @@
-from PyQt5.QtWidgets import QMessageBox
+from pyqtgraph.Qt.QtWidgets import QMessageBox
 
 
 def message_dialog(window_title, message_text):
     alert = QMessageBox()
     alert.setWindowTitle(window_title)
     alert.setText(message_text)
-    alert.exec_()
+    alert.exec()
 
 
 def error_message(message_text):

--- a/tofu/ez/GUI/verify_delete.py
+++ b/tofu/ez/GUI/verify_delete.py
@@ -1,7 +1,7 @@
 import os
 from shutil import rmtree
 
-from PyQt5.QtWidgets import QMessageBox
+from pyqtgraph.Qt.QtWidgets import QMessageBox
 
 from tofu.ez.GUI.message_dialog import warning_message
 
@@ -10,8 +10,8 @@ def verify_safe2delete(parent, dir_path, dir_type):
     if os.path.exists(dir_path) and len(os.listdir(dir_path)) > 0:
         qm = QMessageBox()
         rep = qm.question(parent, '', f"{dir_type} dir is not empty. Is it safe to delete it?\n\n{dir_path}",
-                          qm.Yes | qm.No)
-        if rep == qm.Yes:
+                          qm.StandardButton.Yes | qm.StandardButton.No)
+        if rep == qm.StandardButton.Yes:
             try:
                 rmtree(dir_path)
             except:

--- a/tofu/ez/util.py
+++ b/tofu/ez/util.py
@@ -10,8 +10,8 @@ from tofu.ez.ctdir_walker import VALID_EXTS
 from tofu.ez.params import EZVARS, EZVARS_aux
 from tofu.config import SECTIONS
 from tofu.util import get_filenames, get_first_filename, get_image_shape, read_image, restrict_value, tupleize
-from PyQt5.QtCore import QRegExp
-from PyQt5.QtGui import QRegExpValidator
+from pyqtgraph.Qt.QtCore import QRegularExpression
+from pyqtgraph.Qt.QtGui import QRegularExpressionValidator
 import argparse
 from tofu.util import TiffSequenceReader
 import numpy as np
@@ -400,33 +400,33 @@ def add_value_to_dict_entry(dict_entry, value):
 def get_ascii_validator():
     """Returns a validator that only allows the input of visible ASCII characters"""
     regexp = "[-A-Za-z0-9_]*"
-    return QRegExpValidator(QRegExp(regexp))
+    return QRegularExpressionValidator(QRegularExpression(regexp))
 
 
 def get_alphabet_lowercase_validator():
     """Returns a validator that only allows the input of lowercase ASCII characters"""
     regexp = "[a-z]*"
-    return QRegExpValidator(QRegExp(regexp))
+    return QRegularExpressionValidator(QRegularExpression(regexp))
 
 
 def get_int_validator():
     """Returns a validator that only allows the input of integers"""
     # Note: QIntValidator allows commas, which is undesirable
     regexp = "[\-]?[0-9]*"
-    return QRegExpValidator(QRegExp(regexp))
+    return QRegularExpressionValidator(QRegularExpression(regexp))
 
 
 def get_double_validator():
     """Returns a validator that only allows the input of floating point number"""
     # Note: QDoubleValidator allows commas before period, which is undesirable
     regexp = "[\-]?[0-9]*[.]?[0-9]*"
-    return QRegExpValidator(QRegExp(regexp))
+    return QRegularExpressionValidator(QRegularExpression(regexp))
 
 
 def get_tuple_validator():
     """Returns a validator that only allows a tuple of floating point numbers"""
     regexp = "[-0-9,.]*"
-    return QRegExpValidator(QRegExp(regexp))
+    return QRegularExpressionValidator(QRegularExpression(regexp))
 
 
 def load_values_from_ezdefault(dict):

--- a/tofu/flow/execution.py
+++ b/tofu/flow/execution.py
@@ -6,7 +6,7 @@ try:
 except ValueError:
     gi.require_version('Ufo', '1.0')
 from gi.repository import Ufo
-from PyQt5.QtCore import QObject, pyqtSignal
+from pyqtgraph.Qt.QtCore import QObject, pyqtSignal
 from qtpynodeeditor import PortType
 from threading import Thread
 from tofu.flow.models import ARRAY_DATA_TYPE, UFO_DATA_TYPE, UfoTaskModel

--- a/tofu/flow/filedirdialog.py
+++ b/tofu/flow/filedirdialog.py
@@ -1,5 +1,5 @@
 import os
-from PyQt5.QtWidgets import QFileDialog
+from pyqtgraph.Qt.QtWidgets import QFileDialog
 
 
 class FileDirDialog(QFileDialog):

--- a/tofu/flow/filedirdialog.py
+++ b/tofu/flow/filedirdialog.py
@@ -13,12 +13,12 @@ class FileDirDialog(QFileDialog):
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)
-        self.setOption(QFileDialog.DontUseNativeDialog)
-        self.setFileMode(QFileDialog.Directory)
+        self.setOption(QFileDialog.Option.DontUseNativeDialog)
+        self.setFileMode(QFileDialog.FileMode.Directory)
         self.currentChanged.connect(self._selected)
 
     def _selected(self, name):
         if os.path.isdir(name):
-            self.setFileMode(QFileDialog.Directory)
+            self.setFileMode(QFileDialog.FileMode.Directory)
         else:
-            self.setFileMode(QFileDialog.ExistingFile)
+            self.setFileMode(QFileDialog.FileMode.ExistingFile)

--- a/tofu/flow/main.py
+++ b/tofu/flow/main.py
@@ -3,9 +3,9 @@ import logging
 import os
 import pathlib
 import sys
-from PyQt5.QtCore import Qt, QObject, QPoint, pyqtSignal
-from PyQt5.QtWidgets import (QApplication, QFileDialog, QWidget, QVBoxLayout, QMenuBar,
-                             QMessageBox, QProgressBar, QMainWindow, QStyle)
+from pyqtgraph.Qt.QtCore import Qt, QObject, QPoint, pyqtSignal
+from pyqtgraph.Qt.QtWidgets import (QApplication, QFileDialog, QWidget, QVBoxLayout, QMenuBar,
+                                    QMessageBox, QProgressBar, QMainWindow, QStyle)
 from qtpynodeeditor import DataModelRegistry, FlowView
 import xdg.BaseDirectory
 
@@ -182,7 +182,7 @@ class ApplicationWindow(QMainWindow):
         msg.setIcon(QMessageBox.Critical)
         msg.setText(text)
         msg.setWindowTitle("Error")
-        msg.exec_()
+        msg.exec()
 
     def on_number_of_inputs_changed(self, value):
         self.progress_bar.setMaximum(value)
@@ -352,7 +352,7 @@ class ApplicationWindow(QMainWindow):
             msg.setDetailedText('\n'.join([f'Node name "{name}" from file "{file_name}"'
                                            for (name, file_name) in overwriting.items()]))
             msg.setWindowTitle('Warning')
-            msg.exec_()
+            msg.exec()
 
     def export_composite(self, node, file_name):
         state = node.model.save()
@@ -403,7 +403,7 @@ class ApplicationWindow(QMainWindow):
             self.console = PythonConsole(formats={
                 'keyword': format('darkBlue', 'bold')
             })
-            self.console.setWindowFlag(Qt.SubWindow, True)
+            self.console.setWindowFlag(Qt.WindowType.SubWindow, True)
             self.console.ctrl_d_exits_console(True)
             self.console.push_local_ns('scene', self.ufo_scene)
             self.console.resize(640, 480)
@@ -418,7 +418,7 @@ class ApplicationWindow(QMainWindow):
             msg = QMessageBox(parent=self)
             msg.setIcon(QMessageBox.Information)
             msg.setText('Click on an input field in the flow to connect the slider')
-            msg.exec_()
+            msg.exec()
         else:
             self.run_slider.show()
             # Make sure it goes to the front if it is currently burried under other windows
@@ -526,7 +526,7 @@ def main():
     sys.excepthook = exception_handler.excepthook
 
     main_window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/tofu/flow/main.py
+++ b/tofu/flow/main.py
@@ -416,7 +416,7 @@ class ApplicationWindow(QMainWindow):
     def on_run_slider_action(self):
         if not self.run_slider.view_item:
             msg = QMessageBox(parent=self)
-            msg.setIcon(QMessageBox.Information)
+            msg.setIcon(QMessageBox.Icon.Information)
             msg.setText('Click on an input field in the flow to connect the slider')
             msg.exec()
         else:

--- a/tofu/flow/models.py
+++ b/tofu/flow/models.py
@@ -16,11 +16,11 @@ try:
 except ValueError:
     gi.require_version('Ufo', '1.0')
 from gi.repository import Ufo
-from PyQt5 import QtCore
-from PyQt5.QtCore import QObject, Qt, pyqtSignal
-from PyQt5.QtGui import QDoubleValidator, QValidator
-from PyQt5.QtWidgets import (QCheckBox, QComboBox, QGroupBox, QInputDialog, QLabel, QLineEdit,
-                             QScrollArea, QWidget, QFileDialog, QFormLayout, QVBoxLayout, QMenu)
+from pyqtgraph.Qt import QtCore
+from pyqtgraph.Qt.QtCore import QObject, Qt, pyqtSignal
+from pyqtgraph.Qt.QtGui import QDoubleValidator, QValidator
+from pyqtgraph.Qt.QtWidgets import (QCheckBox, QComboBox, QGroupBox, QInputDialog, QLabel, QLineEdit,
+                                    QScrollArea, QWidget, QFileDialog, QFormLayout, QVBoxLayout, QMenu)
 from qtpynodeeditor import (NodeData, NodeDataModel, NodeDataType, FlowScene, FlowView, Port,
                             PortType, opposite_port)
 from threading import Lock
@@ -416,7 +416,7 @@ class PropertyView(QWidget):
         show_all_action = contextMenu.addAction('Show All')
         hide_all_action = contextMenu.addAction('Hide All')
 
-        action = contextMenu.exec_(self.mapToGlobal(event.pos()))
+        action = contextMenu.exec(self.mapToGlobal(event.pos()))
         if action:
             if action in actions:
                 name = actions[action]
@@ -502,7 +502,7 @@ class MultiPropertyView(QWidget):
         show_all_action = contextMenu.addAction('Show All')
         hide_all_action = contextMenu.addAction('Hide All')
 
-        action = contextMenu.exec_(self.mapToGlobal(event.pos()))
+        action = contextMenu.exec(self.mapToGlobal(event.pos()))
         if action:
             if action in actions:
                 name = actions[action]
@@ -1098,7 +1098,7 @@ class BaseCompositeModel(UfoModel):
         self._other_scene.connection_created.connect(self.on_connection_created)
         self._other_scene.connection_deleted.connect(self.on_connection_deleted)
         self._other_view = FlowView(self._other_scene, parent=parent)
-        self._other_view.setWindowFlag(Qt.Window, True)
+        self._other_view.setWindowFlag(Qt.WindowType.Window, True)
         self._other_view.closeEvent = self.view_close_event
         self._other_view.setWindowTitle(self.name)
         self._other_view.resize(900, 600)
@@ -1332,7 +1332,7 @@ class UfoReadModel(UfoTaskModel):
         if not current_path:
             current_path = QtCore.QDir.homePath()
         dialog = FileDirDialog()
-        if dialog.exec_():
+        if dialog.exec():
             self['path'] = dialog.selectedFiles()[0]
 
     def _setup_ufo_task(self, ufo_task, region=None):

--- a/tofu/flow/propertylinksmodels.py
+++ b/tofu/flow/propertylinksmodels.py
@@ -1,6 +1,6 @@
 import logging
-from PyQt5.QtCore import QDataStream, pyqtSignal
-from PyQt5.QtGui import QStandardItemModel, QStandardItem
+from pyqtgraph.Qt.QtCore import QDataStream, pyqtSignal
+from pyqtgraph.Qt.QtGui import QStandardItemModel, QStandardItem
 from tofu.flow.models import PropertyModel, BaseCompositeModel
 from tofu.flow.util import MODEL_ROLE, NODE_ROLE, PROPERTY_ROLE
 

--- a/tofu/flow/propertylinkswidget.py
+++ b/tofu/flow/propertylinkswidget.py
@@ -1,13 +1,13 @@
-from PyQt5.QtCore import QMimeData, Qt, QDataStream, QByteArray, QIODevice, QModelIndex
-from PyQt5.QtGui import QDrag
-from PyQt5.QtWidgets import QAbstractItemView, QLabel, QTableView, QTreeView, QVBoxLayout, QWidget
+from pyqtgraph.Qt.QtCore import QMimeData, Qt, QDataStream, QByteArray, QIODevice, QModelIndex
+from pyqtgraph.Qt.QtGui import QDrag
+from pyqtgraph.Qt.QtWidgets import QAbstractItemView, QLabel, QTableView, QTreeView, QVBoxLayout, QWidget
 
 
 def _encode_mime_data(index: QModelIndex):
     """Encode item in *index* into :class:`QMimeData`."""
     mime_data = QMimeData()
     data = QByteArray()
-    stream = QDataStream(data, QIODevice.WriteOnly)
+    stream = QDataStream(data, QIODevice.OpenModeFlag.WriteOnly)
     try:
         stream.writeInt32(index.row())
         stream.writeInt32(index.column())
@@ -24,7 +24,7 @@ class PropertyLinksView(QTableView):
     """Table view for displaying node property links."""
 
     def keyPressEvent(self, event):
-        if event.key() == Qt.Key_Delete:
+        if event.key() == Qt.Key.Key_Delete:
             model = self.model()
             for index in self.selectedIndexes():
                 model.remove_item(index)
@@ -56,7 +56,7 @@ class NodesView(QTreeView):
         drag = QDrag(self)
         mime_data = _encode_mime_data(index)
         drag.setMimeData(mime_data)
-        drag.exec_(Qt.CopyAction)
+        drag.exec(Qt.DropAction.CopyAction)
 
         return True
 
@@ -66,7 +66,7 @@ class PropertyLinks(QWidget):
     """Widget displaying nodes in the scene and their property links in one window."""
 
     def __init__(self, node_model, table_model, parent=None):
-        super().__init__(parent=parent, flags=Qt.Window)
+        super().__init__(parent=parent, flags=Qt.WindowType.Window)
         self.setWindowTitle('Property Links')
         self.resize(600, 800)
 
@@ -94,7 +94,7 @@ class PropertyLinks(QWidget):
 
     def show(self):
         self._table_view.resizeColumnsToContents()
-        self._treeview.sortByColumn(0, Qt.AscendingOrder)
+        self._treeview.sortByColumn(0, Qt.SortOrder.AscendingOrder)
         super().show()
 
     def on_table_model_changed(self, item):
@@ -107,4 +107,4 @@ class PropertyLinks(QWidget):
         self._table_view.resizeColumnsToContents()
 
     def on_node_model_changed(self, item):
-        self._treeview.sortByColumn(0, Qt.AscendingOrder)
+        self._treeview.sortByColumn(0, Qt.SortOrder.AscendingOrder)

--- a/tofu/flow/runslider.py
+++ b/tofu/flow/runslider.py
@@ -1,7 +1,7 @@
 from functools import partial
-from PyQt5.QtCore import Qt, pyqtSignal, QTimer
-from PyQt5 import QtGui
-from PyQt5.QtWidgets import QGridLayout, QLineEdit, QWidget, QSlider
+from pyqtgraph.Qt.QtCore import Qt, pyqtSignal, QTimer
+from pyqtgraph.Qt import QtGui
+from pyqtgraph.Qt.QtWidgets import QGridLayout, QLineEdit, QWidget, QSlider
 from tofu.flow.models import IntQLineEditViewItem, RangeQLineEditViewItem, UfoIntValidator
 from tofu.flow.util import FlowError
 
@@ -10,8 +10,8 @@ class RunSlider(QWidget):
     value_changed = pyqtSignal(float)
 
     def __init__(self, parent=None):
-        super().__init__(parent=parent, flags=Qt.Window)
-        self.setWindowFlag(Qt.WindowStaysOnTopHint)
+        super().__init__(parent=parent, flags=Qt.WindowType.Window)
+        self.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint)
         self.setMaximumHeight(20)
         self.setMinimumWidth(600)
         self.min_edit = QLineEdit()
@@ -25,13 +25,13 @@ class RunSlider(QWidget):
         self.max_edit.setToolTip('Maximum')
         self.max_edit.setMaximumWidth(80)
         self.max_edit.editingFinished.connect(self.on_max_edit_editing_finished)
-        self.slider = QSlider(orientation=Qt.Horizontal)
+        self.slider = QSlider(orientation=Qt.Orientation.Horizontal)
         self.slider.setMinimum(0)
         self.slider.setMaximum(100)
         self.slider.valueChanged.connect(self.on_slider_value_changed)
 
         main_layout = QGridLayout()
-        main_layout.addWidget(self.current_edit, 0, 0, 1, 3, Qt.AlignHCenter)
+        main_layout.addWidget(self.current_edit, 0, 0, 1, 3, Qt.AlignmentFlag.AlignHCenter)
         main_layout.addWidget(self.min_edit, 1, 0)
         main_layout.addWidget(self.slider, 1, 1)
         main_layout.addWidget(self.max_edit, 1, 2)

--- a/tofu/flow/scene.py
+++ b/tofu/flow/scene.py
@@ -1,8 +1,8 @@
 import logging
 import numpy as np
 import networkx as nx
-from PyQt5.QtCore import pyqtSignal, QObject
-from PyQt5.QtWidgets import QInputDialog
+from pyqtgraph.Qt.QtCore import pyqtSignal, QObject
+from pyqtgraph.Qt.QtWidgets import QInputDialog
 from qtpynodeeditor import FlowScene, NodeDataModel, PortType, opposite_port
 
 from tofu.flow.models import (BaseCompositeModel, ImageViewerModel, PropertyModel,

--- a/tofu/flow/util.py
+++ b/tofu/flow/util.py
@@ -1,11 +1,11 @@
 import contextlib
 import json
 import pkg_resources
-from PyQt5.QtCore import Qt
+from pyqtgraph.Qt.QtCore import Qt
 from qtpynodeeditor import PortType
 
 
-MODEL_ROLE = Qt.UserRole + 1
+MODEL_ROLE = Qt.ItemDataRole.UserRole + 1
 PROPERTY_ROLE = MODEL_ROLE + 1
 NODE_ROLE = PROPERTY_ROLE + 1
 

--- a/tofu/flow/viewer.py
+++ b/tofu/flow/viewer.py
@@ -1,9 +1,9 @@
 import logging
 import numpy as np
 import os
-from PyQt5 import QtGui
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QFileDialog, QGridLayout, QLabel, QLineEdit, QMenu, QWidget, QSlider
+from pyqtgraph.Qt import QtGui
+from pyqtgraph.Qt.QtCore import Qt
+from pyqtgraph.Qt.QtWidgets import QFileDialog, QGridLayout, QLabel, QLineEdit, QMenu, QWidget, QSlider
 from tofu.flow.util import FlowError
 
 
@@ -144,7 +144,7 @@ class ImageLabel(QLabel):
             vd = self.screen_image.image.shape[0] // self.height()
             downsampling = max(min(hd, vd), 1)
             pixmap = self.screen_image.get_pixmap(downsampling=downsampling)
-            self.setPixmap(pixmap.scaled(self.width(), self.height(), Qt.KeepAspectRatio))
+            self.setPixmap(pixmap.scaled(self.width(), self.height(), Qt.AspectRatioMode.KeepAspectRatio))
 
     def resizeEvent(self, event):
         self.updateImage()
@@ -164,17 +164,17 @@ class ImageViewer(QWidget):
         self.new_image_auto_levels = True
 
         self.label = ImageLabel(self.screen_image)
-        self.label.setAlignment(Qt.AlignVCenter | Qt.AlignCenter)
+        self.label.setAlignment(Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignCenter)
         self.slider_edit = QLineEdit()
         self.slider_edit.setFixedSize(self.edit_width, self.edit_height)
         self.slider_edit.returnPressed.connect(self.on_slider_edit_return_pressed)
-        self.slider = QSlider(Qt.Horizontal)
+        self.slider = QSlider(Qt.Orientation.Horizontal)
         validator = QtGui.QIntValidator(0, self.slider.maximum())
         self.slider_edit.setValidator(validator)
         self.slider.valueChanged.connect(self.on_slider_value_changed)
 
-        self.min_slider = QSlider(Qt.Horizontal)
-        self.max_slider = QSlider(Qt.Horizontal)
+        self.min_slider = QSlider(Qt.Orientation.Horizontal)
+        self.max_slider = QSlider(Qt.Orientation.Horizontal)
         self.min_slider_edit = QLineEdit()
         self.min_slider_edit.setFixedSize(self.edit_width, self.edit_height)
         self.max_slider_edit = QLineEdit()
@@ -229,7 +229,7 @@ class ImageViewer(QWidget):
         except:
             LOG.debug('imageio not installed, save option disabled')
 
-        action = contextMenu.exec_(self.mapToGlobal(event.pos()))
+        action = contextMenu.exec(self.mapToGlobal(event.pos()))
         if not action:
             return
 
@@ -384,7 +384,7 @@ class ImageViewer(QWidget):
 
         self._pg_window = pyqtgraph.ImageView(view=pyqtgraph.PlotItem())
         self._pg_window.imageItem.scene().sigMouseMoved.connect(pg_mouse_moved)
-        self._pg_window.setWindowFlag(Qt.SubWindow, True)
+        self._pg_window.setWindowFlag(Qt.WindowType.SubWindow, True)
         self._update_pg_window_images()
         self._update_pg_window_index()
         self._update_pg_window_lut()

--- a/tofu/gui.py
+++ b/tofu/gui.py
@@ -11,7 +11,11 @@ from tofu import reco, config, util, __version__
 
 try:
     import tofu.vis.qt
-    from PyQt5 import QtGui, QtCore, uic, QtWidgets
+    from pyqtgraph.Qt import QtGui, QtCore, QtWidgets
+    try:
+        from PyQt5 import uic
+    except ImportError:
+        from PyQt6 import uic
 except ImportError:
     raise ImportError("Cannot import modules for GUI, please install tofu with [gui] extras.")
 
@@ -42,7 +46,7 @@ def get_filtered_filenames(path, exts=['.tif', '.edf']):
 
 @contextmanager
 def spinning_cursor():
-    QtWidgets.QApplication.setOverrideCursor(QtWidgets.QCursor(QtCore.Qt.WaitCursor))
+    QtWidgets.QApplication.setOverrideCursor(QtWidgets.QCursor(QtCore.Qt.CursorShape.WaitCursor))
     yield
     QtWidgets.QApplication.restoreOverrideCursor()
 
@@ -64,7 +68,7 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         ui_file = pkg_resources.resource_filename(__name__, 'gui.ui')
         self.ui = uic.loadUi(ui_file, self)
         self.ui.show()
-        self.ui.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        self.ui.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
         self.ui.tab_widget.setCurrentIndex(0)
         self.ui.slice_dock.setVisible(False)
         self.ui.volume_dock.setVisible(False)
@@ -512,4 +516,4 @@ class ApplicationWindow(QtWidgets.QMainWindow):
 def main(params):
     app = QtWidgets.QApplication(sys.argv)
     ApplicationWindow(app, params)
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/tofu/tests/conftest.py
+++ b/tofu/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from PyQt5.QtWidgets import QInputDialog
+from pyqtgraph.Qt.QtWidgets import QInputDialog
 from tofu.flow.main import get_filled_registry
 from tofu.flow.scene import UfoScene
 from tofu.flow.propertylinksmodels import PropertyLinksModel, NodeTreeModel

--- a/tofu/tests/test_flow_main.py
+++ b/tofu/tests/test_flow_main.py
@@ -5,7 +5,7 @@ import pkg_resources
 import pytest
 import sys
 import xdg.BaseDirectory
-from PyQt5.QtWidgets import QFileDialog, QInputDialog, QMessageBox
+from pyqtgraph.Qt.QtWidgets import QFileDialog, QInputDialog, QMessageBox
 from tofu.flow.execution import UfoExecutor
 from tofu.flow.main import ApplicationWindow, get_filled_registry, GlobalExceptionHandler
 from tofu.flow.scene import UfoScene
@@ -86,7 +86,7 @@ class TestApplicationWindow:
             self.message_shown = True
 
         self.message_shown = False
-        monkeypatch.setattr(QMessageBox, "exec_", exec_)
+        monkeypatch.setattr(QMessageBox, "exec", exec_)
         app_window.on_exception_occured('foo')
 
         assert self.message_shown
@@ -300,7 +300,7 @@ class TestApplicationWindow:
         def exec_(inst):
             self.message_shown = True
 
-        monkeypatch.setattr(QMessageBox, "exec_", exec_)
+        monkeypatch.setattr(QMessageBox, "exec", exec_)
 
         # Nothing opened, nothing happens
         monkeypatch.setattr(QFileDialog, "getOpenFileNames", lambda *args: ([], True))

--- a/tofu/tests/test_flow_models.py
+++ b/tofu/tests/test_flow_models.py
@@ -1,8 +1,8 @@
 import pytest
 import numpy as np
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QValidator
-from PyQt5.QtWidgets import QFileDialog, QInputDialog, QLineEdit
+from pyqtgraph.Qt.QtCore import Qt
+from pyqtgraph.Qt.QtGui import QValidator
+from pyqtgraph.Qt.QtWidgets import QFileDialog, QInputDialog, QLineEdit
 from tofu.flow.main import get_filled_registry
 from tofu.flow.models import (CheckBoxViewItem, ComboBoxViewItem, get_composite_model_class,
                               get_composite_model_classes, get_composite_model_classes_from_json,
@@ -271,7 +271,7 @@ def test_check_box_view_item(qtbot):
     assert not vit.get()
 
     check_property_changed_emit(qtbot, vit, True, qtbot.mouseClick,
-                                (vit.widget, Qt.LeftButton), show=True)
+                                (vit.widget, Qt.MouseButton.LeftButton), show=True)
 
 
 def test_combo_box_view_item(qtbot):
@@ -1190,7 +1190,7 @@ class TestUfoReadModel:
     def test_double_clicked(self, qtbot, monkeypatch, read_model):
         from tofu.flow.filedirdialog import FileDirDialog
 
-        monkeypatch.setattr(FileDirDialog, "exec_", lambda *args: 1)
+        monkeypatch.setattr(FileDirDialog, "exec", lambda *args: 1)
         monkeypatch.setattr(FileDirDialog, "selectedFiles", lambda *args: ['foobarbaz'])
         read_model.double_clicked(None)
         assert read_model['path'] == 'foobarbaz'

--- a/tofu/tests/test_flow_propertylinkswidget.py
+++ b/tofu/tests/test_flow_propertylinkswidget.py
@@ -1,5 +1,5 @@
 import pytest
-from PyQt5.QtCore import Qt, QItemSelectionModel
+from pyqtgraph.Qt.QtCore import Qt, QItemSelectionModel
 from tofu.flow.propertylinkswidget import NodesView, PropertyLinks, PropertyLinksView
 from tofu.tests.flow_util import get_index_from_treemodel, populate_link_model
 
@@ -31,7 +31,7 @@ def test_property_links_view_delete_key(qtbot, link_model, link_view, nodes):
     link_view.setModel(link_model)
     populate_link_model(link_model, nodes)
     link_view.selectColumn(0)
-    qtbot.keyPress(link_view, Qt.Key_Delete)
+    qtbot.keyPress(link_view, Qt.Key.Key_Delete)
     assert link_model.columnCount() == 2
 
 

--- a/tofu/tests/test_flow_scene.py
+++ b/tofu/tests/test_flow_scene.py
@@ -1,6 +1,6 @@
 import pytest
-from PyQt5.QtCore import QModelIndex
-from PyQt5.QtWidgets import QInputDialog
+from pyqtgraph.Qt.QtCore import QModelIndex
+from pyqtgraph.Qt.QtWidgets import QInputDialog
 from qtpynodeeditor import FlowView
 from tofu.flow.models import BaseCompositeModel, UfoModelError, UfoReadModel
 from tofu.flow.util import FlowError, MODEL_ROLE, NODE_ROLE, PROPERTY_ROLE

--- a/tofu/tests/test_flow_util.py
+++ b/tofu/tests/test_flow_util.py
@@ -1,5 +1,5 @@
 import pytest
-from PyQt5.QtWidgets import QInputDialog
+from pyqtgraph.Qt.QtWidgets import QInputDialog
 from tofu.flow.util import CompositeConnection, get_config_key, saved_kwargs
 from tofu.flow.main import get_filled_registry
 

--- a/tofu/tests/test_flow_viewer.py
+++ b/tofu/tests/test_flow_viewer.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from PyQt5.QtGui import QValidator
+from pyqtgraph.Qt.QtGui import QValidator
 from tofu.flow.viewer import ImageLabel, ImageViewingError, ScreenImage, ImageViewer
 
 

--- a/tofu/vis/qt.py
+++ b/tofu/vis/qt.py
@@ -7,7 +7,7 @@ import logging
 import numpy as np
 import tifffile
 
-from PyQt5 import QtCore, QtWidgets
+from pyqtgraph.Qt import QtCore, QtWidgets
 
 
 LOG = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ class ImageViewer(QtWidgets.QWidget):
         image_view.getView().setAspectLocked(True)
         self.image_item = image_view.getImageItem()
 
-        self.slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.slider = QtWidgets.QSlider(QtCore.Qt.Orientation.Horizontal)
         self.slider.valueChanged.connect(self.update_image)
 
         self.main_layout = QtWidgets.QVBoxLayout(self)
@@ -106,7 +106,7 @@ class OverlapViewer(QtWidgets.QWidget):
         image_view.getView().setAspectLocked(True)
         self.image_item = image_view.getImageItem()
 
-        self.slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.slider = QtWidgets.QSlider(QtCore.Qt.Orientation.Horizontal)
         self.slider.setRange(0, 0)
         self.slider.valueChanged.connect(self.update_image)
 


### PR DESCRIPTION
Replace all direct PyQt5 imports with pyqtgraph.Qt abstraction layer (pyqtgraph.Qt.QtCore, pyqtgraph.Qt.QtWidgets, etc.) so the project works with both PyQt5 and PyQt6 without code changes.

- Replace `from PyQt5.QtXxx import` with `from pyqtgraph.Qt.QtXxx import` across all modules in tofu/flow/, tofu/ez/GUI/, tofu/tests/, and tofu/vis/qt.py
- Use `from pyqtgraph.Qt import QtGui/QtCore/QtWidgets` for namespace imports
- Keep a PyQt5->PyQt6 fallback only for `uic` in tofu/gui.py, which is not exposed through the pyqtgraph abstraction
- Replace removed-in-Qt6 QRegExp/QRegExpValidator with QRegularExpression/QRegularExpressionValidator in tofu/ez/util.py
- Change all .exec_() calls to .exec() (valid in both Qt5 and Qt6)
- Change the enum paths (flat style not available with PyQt6)
- Update test monkeypatches from "exec_" to "exec" accordingly
- Remove hardcoded PyQt5 from setup.py extras_require; pyqtgraph already handles binding selection

Closes: #155