### PR TITLE
ez: clean tmp dirs after each run

### DIFF
--- a/tofu/ez/GUI/Advanced/ffc.py
+++ b/tofu/ez/GUI/Advanced/ffc.py
@@ -77,8 +77,8 @@ class FFCGroup(QGroupBox):
 
         reduction_layout = QHBoxLayout()
         reduction_layout.addWidget(self.reduction_label)
-        reduction_layout.addWidget(self.median_reduction_rButton)
         reduction_layout.addWidget(self.average_reduction_rButton)
+        reduction_layout.addWidget(self.median_reduction_rButton)
 
         layout.addLayout(reduction_layout, 1, 0, 1, 2)
 

--- a/tofu/ez/GUI/Advanced/ffc.py
+++ b/tofu/ez/GUI/Advanced/ffc.py
@@ -61,6 +61,12 @@ class FFCGroup(QGroupBox):
         self.flat_scale_entry.setValidator(get_double_validator())
         self.flat_scale_entry.editingFinished.connect(self.set_flat_scale)
 
+        self.reduction_label = QLabel("Reduction Mode:")
+        self.median_reduction_rButton = QRadioButton("Median")
+        self.median_reduction_rButton.clicked.connect(self.set_reduction_mode)
+        self.average_reduction_rButton = QRadioButton("Average")
+        self.average_reduction_rButton.clicked.connect(self.set_reduction_mode)
+
         self.set_layout()
 
     def set_layout(self):
@@ -69,26 +75,34 @@ class FFCGroup(QGroupBox):
         layout.addWidget(self.flat_scale_label, 0, 0)
         layout.addWidget(self.flat_scale_entry, 0, 1)
 
+        reduction_layout = QHBoxLayout()
+        reduction_layout.addWidget(self.reduction_label)
+        reduction_layout.addWidget(self.median_reduction_rButton)
+        reduction_layout.addWidget(self.average_reduction_rButton)
+
+        layout.addLayout(reduction_layout, 1, 0, 1, 2)
+
         rbutton_layout = QHBoxLayout()
         rbutton_layout.addWidget(self.method_label)
         rbutton_layout.addWidget(self.eigen_rButton)
         rbutton_layout.addWidget(self.average_rButton)
         rbutton_layout.addWidget(self.ssim_rButton)
 
-        layout.addWidget(self.enable_sinFFC_checkbox, 1, 0)
-        layout.addItem(rbutton_layout, 2, 0, 1, 2)
-        layout.addWidget(self.eigen_pco_repetitions_label, 3, 0)
-        layout.addWidget(self.eigen_pco_repetitions_entry, 3, 1)
-        layout.addWidget(self.eigen_pco_downsample_label, 4, 0)
-        layout.addWidget(self.eigen_pco_downsample_entry, 4, 1)
-        layout.addWidget(self.downsample_label, 5, 0)
-        layout.addWidget(self.downsample_entry, 5, 1)
+        layout.addWidget(self.enable_sinFFC_checkbox, 2, 0)
+        layout.addItem(rbutton_layout, 3, 0, 1, 2)
+        layout.addWidget(self.eigen_pco_repetitions_label, 4, 0)
+        layout.addWidget(self.eigen_pco_repetitions_entry, 4, 1)
+        layout.addWidget(self.eigen_pco_downsample_label, 5, 0)
+        layout.addWidget(self.eigen_pco_downsample_entry, 5, 1)
+        layout.addWidget(self.downsample_label, 6, 0)
+        layout.addWidget(self.downsample_entry, 6, 1)
 
         self.setLayout(layout)
 
     def load_values(self):
         self.enable_sinFFC_checkbox.setChecked(EZVARS['flat-correction']['smart-ffc']['value'])
         self.set_method_from_params()
+        self.set_reduction_mode_from_params()
         self.eigen_pco_repetitions_entry.setText(str(EZVARS['flat-correction']['eigen-pco-reps']['value']))
         self.eigen_pco_downsample_entry.setText(str(EZVARS['flat-correction']['eigen-pco-downsample']['value']))
         self.downsample_entry.setText(str(EZVARS['flat-correction']['downsample']['value']))
@@ -147,3 +161,19 @@ class FFCGroup(QGroupBox):
             self.eigen_rButton.setChecked(False)
             self.average_rButton.setChecked(False)
             self.ssim_rButton.setChecked(True)
+
+    def set_reduction_mode(self):
+        if self.median_reduction_rButton.isChecked():
+            LOG.debug("Reduction Mode: Median")
+            EZVARS['flat-correction']['reduction-mode']['value'] = "median"
+        elif self.average_reduction_rButton.isChecked():
+            LOG.debug("Reduction Mode: Average")
+            EZVARS['flat-correction']['reduction-mode']['value'] = "average"
+
+    def set_reduction_mode_from_params(self):
+        if EZVARS['flat-correction']['reduction-mode']['value'] == "median":
+            self.median_reduction_rButton.setChecked(True)
+            self.average_reduction_rButton.setChecked(False)
+        elif EZVARS['flat-correction']['reduction-mode']['value'] == "average":
+            self.median_reduction_rButton.setChecked(False)
+            self.average_reduction_rButton.setChecked(True)

--- a/tofu/ez/GUI/Main/config.py
+++ b/tofu/ez/GUI/Main/config.py
@@ -618,13 +618,9 @@ class ConfigGroup(QGroupBox):
         QTimer.singleShot(100, run_reco)
 
     def run_reconstruction(self, batch_run):
-        try:            
-            s = execute_reconstruction()
-            if s:
-                msg = f"Processed {s} sets. See output in terminal for details."
-            else:
-                msg = "All sets are already in Output directory. \n"
-                msg += "Clean it or select a different Output."
+        try:
+            num_proc_sets = execute_reconstruction()
+            msg = f"Processed {num_proc_sets} sets. See output in terminal for details."
             QMessageBox.information(self, "Finished", msg)
             if not EZVARS['inout']['dryrun']['value']:
                 self.signal_reco_done.emit()

--- a/tofu/ez/GUI/Main/config.py
+++ b/tofu/ez/GUI/Main/config.py
@@ -13,6 +13,8 @@ from PyQt5.QtWidgets import (
     QLineEdit,
 )
 from PyQt5.QtCore import QCoreApplication, QTimer, pyqtSignal, Qt
+
+from tofu.ez.GUI.verify_delete import verify_safe2delete
 from tofu.ez.main import execute_reconstruction, clean_tmp_dirs
 from tofu.ez.util import import_values, export_values, get_fdt_names
 from tofu.ez.GUI.message_dialog import warning_message
@@ -613,6 +615,14 @@ class ConfigGroup(QGroupBox):
                 print("Vertical stitching output directory should not be the same as input.")
                 print(f"Adjusting from {EZVARS_aux['vert-sti']['output-dir']['value']} to {vert_out}")
                 add_value_to_dict_entry(EZVARS_aux['vert-sti']['output-dir'], vert_out)
+        if EZVARS['COR']['search-method']['value'] == 5:
+            # Check half-acq workdir "stitched-data" is empty before starting
+            stitched_data_dir_name = os.path.join(EZVARS_aux['half-acq']['workdir']['value'],
+                                                  'stitched-data')
+            try:
+                verify_safe2delete(self, stitched_data_dir_name, "Half-acq stitched data")
+            except FileExistsError:
+                return
         run_reco = partial(self.run_reconstruction, batch_run=False)
         #I had to add a little sleep as on some Linux ditributions params won't fully set before the main() begins
         QTimer.singleShot(100, run_reco)

--- a/tofu/ez/GUI/Stitch_tools_tab/ez_360_overlap_qt.py
+++ b/tofu/ez/GUI/Stitch_tools_tab/ez_360_overlap_qt.py
@@ -202,6 +202,15 @@ class Overlap360Group(QGroupBox):
     def set_patch_size(self):
         add_value_to_dict_entry(EZVARS_aux['find360olap']['patch-size'],
                                 int(self.patch_size_entry.text()))
+
+    def enable_by_trigger_from_main_tab(self, enabled):
+        self.input_dir_button.setEnabled(not enabled)
+        self.input_dir_entry.setEnabled(not enabled)
+        self.temp_dir_button.setEnabled(not enabled)
+        self.temp_dir_entry.setEnabled(not enabled)
+        self.output_dir_button.setEnabled(not enabled)
+        self.output_dir_entry.setEnabled(not enabled)
+
     def set_RR_checkbox(self):
         add_value_to_dict_entry(EZVARS_aux['find360olap']['doRR'], self.doRR.isChecked())
 

--- a/tofu/ez/GUI/Stitch_tools_tab/ezstitch_qt.py
+++ b/tofu/ez/GUI/Stitch_tools_tab/ezstitch_qt.py
@@ -19,7 +19,6 @@ from tofu.ez.Helpers.stitch_funcs import (
     main_sti_mp,
     main_360sti_ufol_depth1,
     find_vert_olap_2_vsteps,
-    find_depth_level_to_CT_sets,
     validate_slice_range,
     get_cube_dims,
 )

--- a/tofu/ez/GUI/Stitch_tools_tab/ezstitch_qt.py
+++ b/tofu/ez/GUI/Stitch_tools_tab/ezstitch_qt.py
@@ -283,7 +283,9 @@ class EZStitchGroup(QGroupBox):
         self.setLayout(layout)
 
     def load_values(self):
+        self.invoke_after_reco_checkbox.blockSignals(True)
         self.invoke_after_reco_checkbox.setChecked(EZVARS_aux['vert-sti']['dovertsti']['value'])
+        self.invoke_after_reco_checkbox.blockSignals(False)
         self.input_dir_entry.setText(str(EZVARS_aux['vert-sti']['input-dir']['value']))
         self.tmp_dir_entry.setText(str(EZVARS_aux['vert-sti']['tmp-dir']['value']))
         self.output_dir_entry.setText(str(EZVARS_aux['vert-sti']['output-dir']['value']))

--- a/tofu/ez/GUI/Stitch_tools_tab/ezstitch_qt.py
+++ b/tofu/ez/GUI/Stitch_tools_tab/ezstitch_qt.py
@@ -23,7 +23,7 @@ from tofu.ez.Helpers.stitch_funcs import (
     get_cube_dims,
 )
 from tofu.ez.GUI.message_dialog import warning_message
-from tofu.ez.util import add_value_to_dict_entry, get_int_validator, get_double_validator
+from tofu.ez.util import add_value_to_dict_entry, get_int_validator, get_double_validator, get_fd_names
 from tofu.ez.util import import_values, export_values, read_image, get_dims
 import glob
 
@@ -570,9 +570,15 @@ class EZStitchGroup(QGroupBox):
             # main_360_mp_depth1(self.parameters['ezstitch_input_dir'],
             #                     EZVARS_aux['vert-sti']['output-dir']['value'],
             #                     self.parameters['ezstitch_axis_of_rotation'], 0)
+            reduction_mode = EZVARS['flat-correction']['reduction-mode']['value']
+            fd_names = get_fd_names()
             main_360sti_ufol_depth1(EZVARS_aux['vert-sti']['input-dir']['value'],
                                EZVARS_aux['vert-sti']['output-dir']['value'],
-                               EZVARS_aux['vert-sti']['cor']['value'], 0)
+                               EZVARS_aux['vert-sti']['cor']['value'],
+                                    cro=0,
+                                    reduction_mode=reduction_mode,
+                                    fd_names=fd_names,
+                                    )
         if os.path.isdir(EZVARS_aux['vert-sti']['output-dir']['value']):
             params_file_path = os.path.join(EZVARS_aux['vert-sti']['output-dir']['value'], 
                                             'ezmview_params.yaml')

--- a/tofu/ez/GUI/Stitch_tools_tab/ezstitch_qt.py
+++ b/tofu/ez/GUI/Stitch_tools_tab/ezstitch_qt.py
@@ -14,6 +14,8 @@ from PyQt5.QtWidgets import (
 )
 from shutil import rmtree
 import logging
+
+from tofu.ez.GUI.verify_delete import verify_safe2delete
 from tofu.ez.params import EZVARS_aux, EZVARS
 from tofu.ez.Helpers.stitch_funcs import (
     main_sti_mp,
@@ -522,19 +524,6 @@ class EZStitchGroup(QGroupBox):
             else:
                 return
 
-    def verify_safe2delete(self, dir_path, dir_type):
-        if os.path.exists(dir_path) and len(os.listdir(dir_path)) > 0:
-            qm = QMessageBox()
-            rep = qm.question(self, '', f"{dir_type} dir is not empty. Is it safe to delete it?",
-                              qm.Yes | qm.No)
-            if rep == qm.Yes:
-                try:
-                    rmtree(dir_path)
-                except:
-                    warning_message(f"Error while deleting {dir_type} directory")
-                    raise FileExistsError
-            else:
-                raise FileExistsError
 
 
 
@@ -542,11 +531,11 @@ class EZStitchGroup(QGroupBox):
         LOG.debug("Stitch button pressed")
 
         try:
-            self.verify_safe2delete(EZVARS_aux['vert-sti']['tmp-dir']['value'], "Temporary")
+            verify_safe2delete(self, EZVARS_aux['vert-sti']['tmp-dir']['value'], "Temporary")
         except FileExistsError:
             return
         try:
-            self.verify_safe2delete(EZVARS_aux['vert-sti']['output-dir']['value'], "Output")
+            verify_safe2delete(self, EZVARS_aux['vert-sti']['output-dir']['value'], "Output")
         except FileExistsError:
             return
         

--- a/tofu/ez/GUI/ezufo_launcher.py
+++ b/tofu/ez/GUI/ezufo_launcher.py
@@ -155,6 +155,9 @@ class GUI(qtw.QWidget):
         self.centre_of_rotation_group.enable_360Batch_Group_in_Advanced.connect(
             self.batch360_group.enable_by_trigger_from_main_tab
         )
+        self.centre_of_rotation_group.enable_360Batch_Group_in_Advanced.connect(
+            self.overlap_group.enable_by_trigger_from_main_tab
+        )
         # self.batch360_group.imported_good_list_signal.connect(
         #     self.update_overlap_list
         # )

--- a/tofu/ez/GUI/verify_delete.py
+++ b/tofu/ez/GUI/verify_delete.py
@@ -1,0 +1,21 @@
+import os
+from shutil import rmtree
+
+from PyQt5.QtWidgets import QMessageBox
+
+from tofu.ez.GUI.message_dialog import warning_message
+
+
+def verify_safe2delete(parent, dir_path, dir_type):
+    if os.path.exists(dir_path) and len(os.listdir(dir_path)) > 0:
+        qm = QMessageBox()
+        rep = qm.question(parent, '', f"{dir_type} dir is not empty. Is it safe to delete it?\n\n{dir_path}",
+                          qm.Yes | qm.No)
+        if rep == qm.Yes:
+            try:
+                rmtree(dir_path)
+            except:
+                warning_message(f"Error while deleting {dir_type} directory")
+                raise FileExistsError
+        else:
+            raise FileExistsError

--- a/tofu/ez/Helpers/batch_search_stitch_360.py
+++ b/tofu/ez/Helpers/batch_search_stitch_360.py
@@ -1,8 +1,10 @@
 from tofu.ez.params import EZVARS_aux, EZVARS
 import os
 from tofu.ez.util import add_value_to_dict_entry
-from tofu.ez.Helpers.stitch_funcs import main_360_mp_depth2
+from tofu.ez.Helpers.stitch_funcs import main_360sti_ufol_depth1, compute_crop
 from tofu.ez.Helpers.find_360_overlap import find_overlap
+from tofu.util import get_first_filename, get_image_shape
+
 
 def batch_stitch():
     #TODO: check that directory is empty - if loaded from params check is not applied
@@ -12,32 +14,35 @@ def batch_stitch():
             len(os.listdir(stitched_data_dir_name)) > 0:
         print("# Clean directory for stitched data")
         return 1
-    add_value_to_dict_entry(EZVARS_aux['stitch360']['olap_switch'], 2)
-    add_value_to_dict_entry(EZVARS_aux['stitch360']['crop'], True)
 
     print(EZVARS_aux['axes-list'])
-    for outscandir in EZVARS_aux['axes-list'].keys():
+    for outscandir, innerloopdict in EZVARS_aux['axes-list'].items():
         print(f"# Stitching half acq mode data in {outscandir}")
-        # setting params for stitch360
-        add_value_to_dict_entry(EZVARS_aux['stitch360']['input-dir'], str(outscandir))
-        add_value_to_dict_entry(EZVARS_aux['stitch360']['output-dir'], os.path.join(
-                               stitched_data_dir_name,
-                               str(outscandir[len(os.path.dirname(outscandir)) + 1:]))
-                               )
-        os.makedirs(EZVARS_aux['stitch360']['output-dir']['value'])
-        add_value_to_dict_entry(EZVARS_aux['stitch360']['olap_list'], '')
-        # extract string of overlaps from the EZVARS_aux['axes-list'] subsections:
-        for innerloopdir in EZVARS_aux['axes-list'][outscandir].keys():
-            EZVARS_aux['stitch360']['olap_list']['value'] += \
-                str(EZVARS_aux['axes-list'][outscandir][innerloopdir]) + ','
-        EZVARS_aux['stitch360']['olap_list']['value'] = \
-            EZVARS_aux['stitch360']['olap_list']['value'][:-1]
+        innerloopdirs = list(innerloopdict)
+        dax = list(innerloopdict.values())
         print(f'# Stitching inner loop CT scans in {outscandir} with '
-              f"overlaps {EZVARS_aux['stitch360']['olap_list']['value']}")
-        try:
-            main_360_mp_depth2()
-        except:
-            return 1
+              f"overlaps {dax}")
+
+        print(f'Overlaps: {dax}')
+        first_tomo_dir = os.path.join(outscandir,
+                                      innerloopdirs[0],
+                                      EZVARS['inout']['tomo-dir']['value'])
+        image_shape = get_image_shape(get_first_filename(first_tomo_dir))
+        cra = compute_crop(dax, image_shape)
+        print(f'Crop by: {cra}')
+        for innerloopdir, ax, crop in zip(innerloopdirs, dax, cra):
+            ctdir = os.path.join(outscandir, innerloopdir)
+            outdir = os.path.join(stitched_data_dir_name, os.path.basename(outscandir), innerloopdir)
+            print("================================================================")
+            print(" -> Working On: " + str(ctdir))
+            print(f"    axis position {ax}, margin to crop {crop} pixels")
+            try:
+                main_360sti_ufol_depth1(indir=ctdir,
+                                        outdir=outdir,
+                                        ax=ax,
+                                        cro=crop,)
+            except:
+                return 1
     return 0
 
 def batch_olap_search():

--- a/tofu/ez/Helpers/batch_search_stitch_360.py
+++ b/tofu/ez/Helpers/batch_search_stitch_360.py
@@ -1,7 +1,7 @@
 from tofu.ez.ctdir_walker import substitute_shared_flatsdarks
 from tofu.ez.params import EZVARS_aux, EZVARS
 import os
-from tofu.ez.util import add_value_to_dict_entry
+from tofu.ez.util import add_value_to_dict_entry, get_fd_names
 from tofu.ez.Helpers.stitch_funcs import main_360sti_ufol_depth1, compute_crop
 from tofu.ez.Helpers.find_360_overlap import find_overlap
 from tofu.util import get_first_filename, get_image_shape
@@ -33,6 +33,8 @@ def batch_stitch():
         print(f'Crop by: {cra}')
 
         substitute_subdirs = substitute_shared_flatsdarks()
+        reduction_mode = EZVARS['flat-correction']['reduction-mode']['value']
+        fd_names = get_fd_names()
 
         for innerloopdir, ax, crop in zip(innerloopdirs, dax, cra):
             ctdir = os.path.join(outscandir, innerloopdir)
@@ -46,6 +48,8 @@ def batch_stitch():
                                         ax=ax,
                                         cro=crop,
                                         substitute_subdirs=substitute_subdirs,
+                                        reduction_mode=reduction_mode,
+                                        fd_names=fd_names,
                                         )
             except:
                 return 1

--- a/tofu/ez/Helpers/batch_search_stitch_360.py
+++ b/tofu/ez/Helpers/batch_search_stitch_360.py
@@ -1,3 +1,4 @@
+from tofu.ez.ctdir_walker import substitute_shared_flatsdarks
 from tofu.ez.params import EZVARS_aux, EZVARS
 import os
 from tofu.ez.util import add_value_to_dict_entry
@@ -30,6 +31,9 @@ def batch_stitch():
         image_shape = get_image_shape(get_first_filename(first_tomo_dir))
         cra = compute_crop(dax, image_shape)
         print(f'Crop by: {cra}')
+
+        substitute_subdirs = substitute_shared_flatsdarks()
+
         for innerloopdir, ax, crop in zip(innerloopdirs, dax, cra):
             ctdir = os.path.join(outscandir, innerloopdir)
             outdir = os.path.join(stitched_data_dir_name, os.path.basename(outscandir), innerloopdir)
@@ -40,7 +44,9 @@ def batch_stitch():
                 main_360sti_ufol_depth1(indir=ctdir,
                                         outdir=outdir,
                                         ax=ax,
-                                        cro=crop,)
+                                        cro=crop,
+                                        substitute_subdirs=substitute_subdirs,
+                                        )
             except:
                 return 1
     return 0

--- a/tofu/ez/Helpers/batch_search_stitch_360.py
+++ b/tofu/ez/Helpers/batch_search_stitch_360.py
@@ -1,7 +1,7 @@
 from tofu.ez.ctdir_walker import substitute_shared_flatsdarks
 from tofu.ez.params import EZVARS_aux, EZVARS
 import os
-from tofu.ez.util import add_value_to_dict_entry, get_fd_names
+from tofu.ez.util import add_value_to_dict_entry, get_fd_names, export_values
 from tofu.ez.Helpers.stitch_funcs import main_360sti_ufol_depth1, compute_crop
 from tofu.ez.Helpers.find_360_overlap import find_overlap
 from tofu.util import get_first_filename, get_image_shape
@@ -19,6 +19,12 @@ def batch_stitch():
     print(EZVARS_aux['axes-list'])
     for outscandir, innerloopdict in EZVARS_aux['axes-list'].items():
         print(f"# Stitching half acq mode data in {outscandir}")
+        outscandir_out = os.path.join(stitched_data_dir_name, os.path.basename(outscandir))
+        if not os.path.exists(outscandir_out):
+            os.makedirs(outscandir_out)
+        # Export the parameters used to get stitched-data
+        export_values(os.path.join(outscandir_out, "tofuez_all_parameters.yaml"),
+                      ['ezvars', 'tofu', 'ezvars_aux'])
         innerloopdirs = list(innerloopdict)
         dax = list(innerloopdict.values())
         print(f'# Stitching inner loop CT scans in {outscandir} with '
@@ -38,7 +44,7 @@ def batch_stitch():
 
         for innerloopdir, ax, crop in zip(innerloopdirs, dax, cra):
             ctdir = os.path.join(outscandir, innerloopdir)
-            outdir = os.path.join(stitched_data_dir_name, os.path.basename(outscandir), innerloopdir)
+            outdir = os.path.join(outscandir_out, innerloopdir)
             print("================================================================")
             print(" -> Working On: " + str(ctdir))
             print(f"    axis position {ax}, margin to crop {crop} pixels")

--- a/tofu/ez/Helpers/find_360_overlap.py
+++ b/tofu/ez/Helpers/find_360_overlap.py
@@ -112,14 +112,18 @@ def find_overlap():
     return dict(zip(ctdirs, olap_estimates))
 
 def make_sinos_noPR(ctset, dirflats, dirdark, dirflats2, ax_range, sin_tmp_dir):
+    reduction_func = np.median
+    if EZVARS['flat-correction']['reduction-mode']['value'] == 'average':
+        reduction_func = np.mean
+
     try:
-        row_flat = np.median(extract_row(
+        row_flat = reduction_func(extract_row(
             os.path.join(ctset, dirflats), EZVARS_aux['find360olap']['row']['value']))
     except:
         print(f"Problem loading flats in {ctset}")
         return 1
     try:
-        row_dark = np.mean(extract_row(
+        row_dark = reduction_func(extract_row(
             os.path.join(ctset, dirdark), EZVARS_aux['find360olap']['row']['value']))
     except:
         print(f"Problem loading darks in {ctset}")
@@ -136,7 +140,7 @@ def make_sinos_noPR(ctset, dirflats, dirdark, dirflats2, ax_range, sin_tmp_dir):
     tmpstr = os.path.join(ctset, dirflats2)
     if os.path.exists(tmpstr):
         try:
-            row_flat2 = np.median(extract_row(tmpstr, EZVARS_aux['find360olap']['row']['value']))
+            row_flat2 = reduction_func(extract_row(tmpstr, EZVARS_aux['find360olap']['row']['value']))
         except:
             print(f"Problem loading flats2 in {ctset}")
             return 1
@@ -243,7 +247,7 @@ def make_sinos_PR(ctset, dirflats, dirdark, dirflats2, ax_range, sin_tmp_dir):
         stitched_pr = os.path.join(EZVARS_aux['find360olap']['tmp-dir']['value'], 'stitched-pr', f"{axis:04}")
         out_pattern = os.path.join(stitched_pr, "proj-%04i.tif")
         print(f"Phase retrieval")
-        cmd = fmt_pr_cmd(*dirs, out_pattern)
+        cmd = fmt_pr_cmd(*dirs, out_pattern, reduction_mode=EZVARS['flat-correction']['reduction-mode']['value'])
         os.system(cmd)
         print(f"Generating sinogram for the target row")
         cmd = "tofu sinos"

--- a/tofu/ez/Helpers/find_360_overlap.py
+++ b/tofu/ez/Helpers/find_360_overlap.py
@@ -18,7 +18,7 @@ from tofu.ez.ufo_cmd_gen import get_filter2d_sinos_cmd
 #from tofu.ez.find_axis_cmd_gen import evaluate_images_simp
 from tofu.ez.evaluate_sharpness import evaluate_metrics_360_olap_search
 from tofu.ez.Helpers.stitch_funcs import main_360sti_ufol_depth1
-from tofu.ez.util import get_dims
+from tofu.ez.util import get_dims, get_fd_names
 from tofu.ez.ufo_cmd_gen import get_pre_cmd
 from tofu.ez.tofu_cmd_gen import fmt_pr_cmd
 
@@ -235,6 +235,8 @@ def make_sinos_PR(ctset, dirflats, dirdark, dirflats2, ax_range, sin_tmp_dir):
     for cmd in cmds:
         #print(cmd)
         os.system(cmd)
+    reduction_mode = EZVARS['flat-correction']['reduction-mode']['value']
+    fd_names = get_fd_names()
     for axis in ax_range:
         print(f"Making sinogram for axis {axis}")
         cro = EZVARS_aux['find360olap']['stop']['value'] - axis
@@ -242,7 +244,10 @@ def make_sinos_PR(ctset, dirflats, dirdark, dirflats2, ax_range, sin_tmp_dir):
             cro = axis - EZVARS_aux['find360olap']['start']['value']
         stitched = os.path.join(EZVARS_aux['find360olap']['tmp-dir']['value'], 'stitched', f"{axis:04}")
         print(f"Stitching flats/darks/tomo")
-        main_360sti_ufol_depth1(path2crop_frames, stitched, axis, cro)
+        main_360sti_ufol_depth1(path2crop_frames, stitched, axis, cro,
+                                reduction_mode=reduction_mode,
+                                fd_names=fd_names,
+                                )
         dirs = (
             os.path.join(stitched, dirdark),
             os.path.join(stitched, dirflats),
@@ -252,7 +257,7 @@ def make_sinos_PR(ctset, dirflats, dirdark, dirflats2, ax_range, sin_tmp_dir):
         stitched_pr = os.path.join(EZVARS_aux['find360olap']['tmp-dir']['value'], 'stitched-pr', f"{axis:04}")
         out_pattern = os.path.join(stitched_pr, "proj-%04i.tif")
         print(f"Phase retrieval")
-        cmd = fmt_pr_cmd(*dirs, out_pattern, reduction_mode=EZVARS['flat-correction']['reduction-mode']['value'])
+        cmd = fmt_pr_cmd(*dirs, out_pattern, reduction_mode=reduction_mode)
         os.system(cmd)
         print(f"Generating sinogram for the target row")
         cmd = "tofu sinos"

--- a/tofu/ez/Helpers/find_360_overlap.py
+++ b/tofu/ez/Helpers/find_360_overlap.py
@@ -18,7 +18,7 @@ from tofu.ez.ufo_cmd_gen import get_filter2d_sinos_cmd
 #from tofu.ez.find_axis_cmd_gen import evaluate_images_simp
 from tofu.ez.evaluate_sharpness import evaluate_metrics_360_olap_search
 from tofu.ez.Helpers.stitch_funcs import main_360sti_ufol_depth1
-from tofu.ez.util import get_data_cube_info, get_dims
+from tofu.ez.util import get_dims
 from tofu.ez.ufo_cmd_gen import get_pre_cmd
 from tofu.ez.tofu_cmd_gen import fmt_pr_cmd
 

--- a/tofu/ez/Helpers/find_360_overlap.py
+++ b/tofu/ez/Helpers/find_360_overlap.py
@@ -29,6 +29,11 @@ def extract_row(dir_name, row):
     if (row < 0) or (row > N):
         row = N//2
     num_images = tsr.num_images
+    if num_images == 1:
+        print(f"Single image in {dir_name}, duplicating.")
+        num_images = 2
+        tsr._filenames = 2 * tsr._filenames
+        assert num_images == tsr.num_images
     if num_images % 2 == 1:
         # print(f"odd number of images ({num_images}) in {dir_name}, "
         #       f"discarding the last one before stitching pairs")

--- a/tofu/ez/Helpers/stitch_funcs.py
+++ b/tofu/ez/Helpers/stitch_funcs.py
@@ -41,23 +41,25 @@ def findCTdirs(root: str, tomo_name: str):
     return ctdirs, lvl0
 
 
-def make_ort_sections(ctset_path):
+def make_ort_sections(ctset_path, tmp_dir_path):
     """
-    :param parameters: GUI params
-    :param dir_type 1 if CTDir containing Z00-Z0N slices - 2 if parent directory containing CTdirs each containing Z slices:
-    :param ctdir Name of the ctdir - blank string if not using multiple ctdirs:
-    :return:
+    Generate orthogonal sections using tofu sinos command.
+    Returns the original path if orthogonal sections are not generated, otherwise returns the path to the orthogonal sections.
+    :param ctset_path: Path to the directory containing the vertical views (one CTDir with Z00-Z0N subdirs)
+    :param tmp_dir_path: Path to the temporary directory where the orthogonal sections will be stored.
+    :return: Path to the directory containing the orthogonal sections and dtype of the input images
     """
     Vsteps = sorted_sub_directories(ctset_path)
     #determine input data type
     tmp = os.path.join(ctset_path, Vsteps[0], EZVARS_aux['vert-sti']['subdir-name']['value'])
     nslices, N, M, indtype_digit, indtype, npasses = get_data_cube_info(tmp)
 
+    indir = ctset_path
     if EZVARS_aux['vert-sti']['ort']['value']:
         print(" - Creating orthogonal sections")
         for vstep in Vsteps:
             in_name = os.path.join(ctset_path, vstep, EZVARS_aux['vert-sti']['subdir-name']['value'])
-            out_name = os.path.join(EZVARS_aux['vert-sti']['tmp-dir']['value'],
+            out_name = os.path.join(tmp_dir_path,
                                     vstep, EZVARS_aux['vert-sti']['subdir-name']['value'], 'sli-%04i.tif')
             # todo: size check and num-passes argument
             cmd = 'tofu sinos --projections {} --output {}'.format(in_name, out_name)
@@ -71,9 +73,7 @@ def make_ort_sections(ctset_path):
             print(cmd)
             os.system(cmd)
             time.sleep(10)
-        indir = EZVARS_aux['vert-sti']['tmp-dir']['value']
-    else:
-        indir = EZVARS_aux['vert-sti']['input-dir']['value']
+        indir = tmp_dir_path
     return indir, indtype
 
 def sorted_sub_directories(path: os.PathLike) -> list[str]:
@@ -150,14 +150,15 @@ def main_sti_mp():
     for vert_set in vert_sets:
         ctdir = os.path.relpath(vert_set, start=EZVARS_aux['vert-sti']['input-dir']['value'])
         print(f"-> Working on {str(ctdir)} dataset")
+        tmpdir = os.path.join(EZVARS_aux['vert-sti']['tmp-dir']['value'], ctdir)
         outdir = os.path.join(EZVARS_aux['vert-sti']['output-dir']['value'], ctdir)
         if not os.path.exists(outdir):
             os.makedirs(outdir)
-        stitch_func(vert_set, outdir)
+        stitch_func(vert_set, tmpdir, outdir)
 
 
-def sti_one_set(in_dir_path, out_dir_path):
-    indir, indtype = make_ort_sections(in_dir_path)
+def sti_one_set(in_dir_path, tmp_dir_path, out_dir_path):
+    indir, indtype = make_ort_sections(in_dir_path, tmp_dir_path)
     outfilepattern = os.path.join(out_dir_path, EZVARS_aux['vert-sti']['subdir-name']['value'] + '-sti-{:>04}.tif')
     if EZVARS_aux['vert-sti']['estimate_num_olap_rows']['value']:
         olap = find_vert_olap_2_vsteps(in_dir_path,
@@ -229,9 +230,9 @@ def exec_sti_mp(indir, pout, N, Nnew, Vsteps, dx, M, ramp, indtype, j):
         tifffile.imwrite(pout, Large.astype(np.float32))
 
 
-def conc_one_set(indir, pout):
-    indir, indtype = make_ort_sections(indir)
-    outfilepattern = os.path.join(pout, EZVARS_aux['vert-sti']['subdir-name']['value'] + '-sti-{:>04}.tif')
+def conc_one_set(in_dir_path, tmp_dir_path, out_dir_path):
+    indir, indtype = make_ort_sections(in_dir_path, tmp_dir_path)
+    outfilepattern = os.path.join(out_dir_path, EZVARS_aux['vert-sti']['subdir-name']['value'] + '-sti-{:>04}.tif')
     zfold = sorted_sub_directories(indir)
     l = len(zfold)
     tmp = glob.glob(os.path.join(indir, zfold[0], EZVARS_aux['vert-sti']['subdir-name']['value'], '*.tif'))

--- a/tofu/ez/Helpers/stitch_funcs.py
+++ b/tofu/ez/Helpers/stitch_funcs.py
@@ -127,35 +127,33 @@ def load_an_image_from_the_input_dir(input_dir, slice_dir):
     return 0
 
 def main_sti_mp():
-    #Check whether indir is CTdir or parent containing CTdirs
-    #if indir + some z00 subdir + sli + *.tif does not exist then use original
     if not os.path.exists(EZVARS_aux['vert-sti']['output-dir']['value']):
         os.makedirs(EZVARS_aux['vert-sti']['output-dir']['value'])
-    subdirs = sorted_sub_directories(EZVARS_aux['vert-sti']['input-dir']['value'])
-    if os.path.exists(os.path.join(EZVARS_aux['vert-sti']['input-dir']['value'], subdirs[0],
-                                   EZVARS_aux['vert-sti']['subdir-name']['value'])):
-        print(" - Working with one CT directory which contains multiple vertical views")
-        if EZVARS_aux['vert-sti']['task_type']['value'] == 0:
-            sti_one_set(EZVARS_aux['vert-sti']['input-dir']['value'],
-                        EZVARS_aux['vert-sti']['output-dir']['value'])
-        else:
-            conc_one_set(EZVARS_aux['vert-sti']['input-dir']['value'],
-                            EZVARS_aux['vert-sti']['output-dir']['value'])
+
+    if EZVARS_aux['vert-sti']['task_type']['value'] == 0:
+        stitch_func = sti_one_set
+    elif EZVARS_aux['vert-sti']['task_type']['value'] == 1:
+        stitch_func = conc_one_set
     else:
-        second_subdirs = sorted_sub_directories(os.path.join(EZVARS_aux['vert-sti']['input-dir']['value'], subdirs[0]))
-        if os.path.exists(os.path.join(EZVARS_aux['vert-sti']['input-dir']['value'], subdirs[0],
-                                       second_subdirs[0], EZVARS_aux['vert-sti']['subdir-name']['value'])):
-            print(" - Working with several CT directories which contain multiple vertical views")
-            for ctdir in subdirs:
-                print(f"-> Working on {str(ctdir)} dataset")
-                indir = os.path.join(EZVARS_aux['vert-sti']['input-dir']['value'], ctdir)
-                outdir = os.path.join(EZVARS_aux['vert-sti']['output-dir']['value'], ctdir)
-                if not os.path.exists(outdir):
-                    os.makedirs(outdir)
-                if EZVARS_aux['vert-sti']['task_type']['value'] == 0:
-                    sti_one_set(indir, outdir)
-                else:
-                    conc_one_set(indir, outdir)
+        raise ValueError("Wrong task type value. Must be 0 for stitching or 1 for concatenation")
+
+    vert_sets = []
+    for root, dirs, files in os.walk(EZVARS_aux['vert-sti']['input-dir']['value']):
+        if EZVARS_aux['vert-sti']['subdir-name']['value'] in dirs:
+            vert_sets.append(os.path.dirname(root))
+    vert_sets = sorted(list(set(vert_sets)))
+    if len(vert_sets) == 1:
+        print(" - Working with one CT directory which contains multiple vertical views")
+    elif len(vert_sets) > 1:
+        print(" - Working with several CT directories which contain multiple vertical views")
+
+    for vert_set in vert_sets:
+        ctdir = os.path.relpath(vert_set, start=EZVARS_aux['vert-sti']['input-dir']['value'])
+        print(f"-> Working on {str(ctdir)} dataset")
+        outdir = os.path.join(EZVARS_aux['vert-sti']['output-dir']['value'], ctdir)
+        if not os.path.exists(outdir):
+            os.makedirs(outdir)
+        stitch_func(vert_set, outdir)
 
 
 def sti_one_set(in_dir_path, out_dir_path):

--- a/tofu/ez/Helpers/stitch_funcs.py
+++ b/tofu/ez/Helpers/stitch_funcs.py
@@ -82,27 +82,29 @@ def sorted_sub_directories(path: os.PathLike) -> list[str]:
         subdirs = sorted([entry.name for entry in entries if entry.is_dir()])
     return subdirs
 
-def find_depth_level_to_CT_sets(input_dir, slice_dir):
-    subdirs = sorted_sub_directories(input_dir)
-    tmp = os.path.join(input_dir, subdirs[0], slice_dir)
-    if os.path.exists(tmp):
-        return 1, tmp
-    second_subdirs = sorted_sub_directories(os.path.join(input_dir, subdirs[0]))
-    tmp = os.path.join(input_dir, subdirs[0], second_subdirs[0], slice_dir)
-    if os.path.exists(tmp):
-        return 2, tmp
-    return 0, ""
 
-def get_cube_dims():
+def get_cube_dims(search_dir=None, subdir_name=None):
     """
     Find the first set of slices and determine the cube dimensions
 
     Returns (number of slices, image_rows, image_columns)
     """
-    _, pth = find_depth_level_to_CT_sets(EZVARS_aux['vert-sti']['input-dir']['value'],
-                                         EZVARS_aux['vert-sti']['subdir-name']['value']
-                                         )
-    nslices, hw, multipage = get_dims(pth)
+    if search_dir is None:
+        search_dir = EZVARS_aux['vert-sti']['input-dir']['value']
+    if subdir_name is None:
+        subdir_name = EZVARS_aux['vert-sti']['subdir-name']['value']
+    path_to_slices = None
+    for root, dirs, files in os.walk(search_dir):
+        for name in dirs:
+            if name == subdir_name:
+                path_to_slices = os.path.join(root, name)
+                break
+        else:
+            continue
+        break
+    if path_to_slices is None:
+        raise FileNotFoundError(f"Could not find a directory named {subdir_name} in {search_dir}")
+    nslices, hw, multipage = get_dims(path_to_slices)
     return nslices, hw[0], hw[1]
 
 

--- a/tofu/ez/Helpers/stitch_funcs.py
+++ b/tofu/ez/Helpers/stitch_funcs.py
@@ -10,7 +10,7 @@ import numpy as np
 import tifffile
 from tofu.util import read_image, get_image_shape, TiffSequenceReader, SequenceReaderError, \
     get_first_filename
-from tofu.ez.util import get_data_cube_info, add_value_to_dict_entry, get_dims
+from tofu.ez.util import get_data_cube_info, add_value_to_dict_entry, get_dims, enquote
 from tofu.ez.image_read_write import get_image_dtype
 import multiprocessing as mp
 from functools import partial
@@ -53,13 +53,13 @@ def make_ort_sections(ctset_path, tmp_dir_path):
     Vsteps = sorted_sub_directories(ctset_path)
     #determine input data type
     tmp = os.path.join(ctset_path, Vsteps[0], EZVARS_aux['vert-sti']['subdir-name']['value'])
-    nslices, N, M, indtype_digit, indtype, npasses = get_data_cube_info(tmp)
+    nslices, N, M, indtype_digit, indtype, npasses, ext = get_data_cube_info(tmp)
 
     indir = ctset_path
     if EZVARS_aux['vert-sti']['ort']['value']:
         print(" - Creating orthogonal sections")
         for vstep in Vsteps:
-            in_name = os.path.join(ctset_path, vstep, EZVARS_aux['vert-sti']['subdir-name']['value'])
+            in_name = enquote(os.path.join(ctset_path, vstep, EZVARS_aux['vert-sti']['subdir-name']['value'], f"*{ext}"))
             out_name = os.path.join(tmp_dir_path,
                                     vstep, EZVARS_aux['vert-sti']['subdir-name']['value'], 'sli-%04i.tif')
             # todo: size check and num-passes argument

--- a/tofu/ez/Helpers/stitch_funcs.py
+++ b/tofu/ez/Helpers/stitch_funcs.py
@@ -354,8 +354,8 @@ def main_360sti_ufol_depth1(indir, outdir, ax, cro):
         numfiles = len(sorted(glob.glob(os.path.join(inpath, '*.tif'))))
         tfs = TiffSequenceReader(inpath)
         numim = tfs.num_images
-        if numim < 2:
-            print("Warning: less than 2 images, skipping this dir")
+        if numim < 1:
+            print("Warning: no images, skipping this dir")
             continue
         if (numfiles > 1) and (numfiles != numim):
             print("Warning: cannot work with several bigtiff files. Input must be either"
@@ -365,7 +365,10 @@ def main_360sti_ufol_depth1(indir, outdir, ax, cro):
         if numfiles == 1:
             bigtiff = True
         numpairs = numim // 2
-        print(f"{numpairs} pairs will be stitched in {sdir}")
+        if numpairs:
+            print(f"{numpairs} pairs will be stitched in {sdir}")
+        elif numpairs == 0:
+            print(f"Single image in {sdir}, duplicating.")
         im = tfs.read(0)
         tfs.close()
         h, w = im.shape

--- a/tofu/ez/Helpers/stitch_funcs.py
+++ b/tofu/ez/Helpers/stitch_funcs.py
@@ -8,6 +8,8 @@ import os
 import shutil
 import numpy as np
 import tifffile
+
+from tofu.ez.ctdir_walker import substitute_shared_flatsdarks
 from tofu.util import read_image, get_image_shape, TiffSequenceReader, SequenceReaderError, \
     get_first_filename
 from tofu.ez.util import get_data_cube_info, add_value_to_dict_entry, get_dims, enquote
@@ -343,15 +345,28 @@ def main_360_mp_depth1(indir, outdir, ax, cro):
             break
     print("========== Done ==========")
 
-def main_360sti_ufol_depth1(indir, outdir, ax, cro):
+def main_360sti_ufol_depth1(indir, outdir, ax, cro, substitute_subdirs=None):
+    """
+    indir: path to ctset with tomo/flats/darks/flats2 subdirectories
+    outdir: path to output directory
+    ax: overlap value
+    cro: desired crop
+    substitute_subdirs: dictionary of subdirs and replacement paths (used for shared flats/darks)
+    """
+    if substitute_subdirs is None:
+        substitute_subdirs = {}
+
     if not os.path.exists(outdir):
         os.makedirs(outdir)
 
-    subdirs = sorted_sub_directories(indir)
+    subdirs_list = sorted_sub_directories(indir)
+    subdirs = {sd: os.path.join(indir, sd) for sd in subdirs_list}
+    subdirs.update(substitute_subdirs)
 
-    for i, sdir in enumerate(subdirs):
+    for sdir, inpath in subdirs.items():
         print(f"Stitching images in {sdir}")
-        inpath = os.path.join(indir, sdir)
+        if sdir in substitute_subdirs:
+            print(f"Using shared path for {sdir}: {inpath}")
         numfiles = len(sorted(glob.glob(os.path.join(inpath, '*.tif'))))
         tfs = TiffSequenceReader(inpath)
         numim = tfs.num_images
@@ -382,7 +397,6 @@ def main_360sti_ufol_depth1(indir, outdir, ax, cro):
         cmd = fmt_stitch_cmd(inpath, bigtiff, bits, outpath, numpairs, w, ax, cro)
         #print(cmd)
         os.system(cmd)
-
 
 def compute_crop(dax, image_shape):
     """Compute the crop values required to output matching image widths after stitching
@@ -435,6 +449,8 @@ def main_360_mp_depth2():
     cra = compute_crop(dax, image_shape)
     print(f'Crop by: {cra}')
 
+    substitute_subdirs = substitute_shared_flatsdarks()
+
     for i, ctdir in enumerate(ctdirs):
         print("================================================================")
         print(" -> Working On: " + str(ctdir))
@@ -443,7 +459,8 @@ def main_360_mp_depth2():
         #main_360_mp_depth1
         main_360sti_ufol_depth1(ctdir,
             os.path.join(EZVARS_aux['stitch360']['output-dir']['value'], ctdirs_rel_paths[i]),
-                           int(dax[i]), int(cra[i]))
+                           int(dax[i]), int(cra[i]),
+                                substitute_subdirs=substitute_subdirs)
 
         # print(ctdir, os.path.join(parameters['360multi_output_dir'], ctdirs_rel_paths[i]), dax[i], cra[i])
 

--- a/tofu/ez/Helpers/stitch_funcs.py
+++ b/tofu/ez/Helpers/stitch_funcs.py
@@ -12,7 +12,7 @@ import tifffile
 from tofu.ez.ctdir_walker import substitute_shared_flatsdarks
 from tofu.util import read_image, get_image_shape, TiffSequenceReader, SequenceReaderError, \
     get_first_filename
-from tofu.ez.util import get_data_cube_info, add_value_to_dict_entry, get_dims, enquote
+from tofu.ez.util import get_data_cube_info, add_value_to_dict_entry, get_dims, enquote, get_fd_names
 from tofu.ez.image_read_write import get_image_dtype
 import multiprocessing as mp
 from functools import partial
@@ -345,13 +345,19 @@ def main_360_mp_depth1(indir, outdir, ax, cro):
             break
     print("========== Done ==========")
 
-def main_360sti_ufol_depth1(indir, outdir, ax, cro, substitute_subdirs=None):
+def main_360sti_ufol_depth1(indir, outdir, ax, cro,
+                            substitute_subdirs=None,
+                            reduction_mode=None,
+                            fd_names=(),
+                            ):
     """
     indir: path to ctset with tomo/flats/darks/flats2 subdirectories
     outdir: path to output directory
     ax: overlap value
     cro: desired crop
     substitute_subdirs: dictionary of subdirs and replacement paths (used for shared flats/darks)
+    reduction_mode: Flats / darks will be reduced by "average" or "median" before stitching
+    fd_names: Sequence of flats / darks / flats2 subdir names in the input ctset
     """
     if substitute_subdirs is None:
         substitute_subdirs = {}
@@ -380,11 +386,17 @@ def main_360sti_ufol_depth1(indir, outdir, ax, cro, substitute_subdirs=None):
         bigtiff = False
         if numfiles == 1:
             bigtiff = True
-        numpairs = numim // 2
-        if numpairs:
-            print(f"{numpairs} pairs will be stitched in {sdir}")
-        elif numpairs == 0:
-            print(f"Single image in {sdir}, duplicating.")
+        if reduction_mode is not None and sdir in fd_names:
+            numpairs = numim
+            current_reduction_mode = reduction_mode
+            print(f"{current_reduction_mode} of {numpairs} images will be stitched for {sdir}")
+        else:
+            numpairs = numim // 2
+            current_reduction_mode = None
+            if numpairs:
+                print(f"{numpairs} pairs will be stitched in {sdir}")
+            elif numpairs == 0:
+                print(f"Single image in {sdir}, duplicating.")
         im = tfs.read(0)
         tfs.close()
         h, w = im.shape
@@ -394,7 +406,7 @@ def main_360sti_ufol_depth1(indir, outdir, ax, cro, substitute_subdirs=None):
         elif im.dtype == 'uint16':
             bits = 16,
         outpath = os.path.join(outdir, sdir)
-        cmd = fmt_stitch_cmd(inpath, bigtiff, bits, outpath, numpairs, w, ax, cro)
+        cmd = fmt_stitch_cmd(inpath, bigtiff, bits, outpath, numpairs, w, ax, cro, current_reduction_mode)
         #print(cmd)
         os.system(cmd)
 
@@ -450,6 +462,8 @@ def main_360_mp_depth2():
     print(f'Crop by: {cra}')
 
     substitute_subdirs = substitute_shared_flatsdarks()
+    reduction_mode = EZVARS['flat-correction']['reduction-mode']['value']
+    fd_names = get_fd_names()
 
     for i, ctdir in enumerate(ctdirs):
         print("================================================================")
@@ -460,7 +474,10 @@ def main_360_mp_depth2():
         main_360sti_ufol_depth1(ctdir,
             os.path.join(EZVARS_aux['stitch360']['output-dir']['value'], ctdirs_rel_paths[i]),
                            int(dax[i]), int(cra[i]),
-                                substitute_subdirs=substitute_subdirs)
+                                substitute_subdirs=substitute_subdirs,
+                                reduction_mode=reduction_mode,
+                                fd_names=fd_names,
+                                )
 
         # print(ctdir, os.path.join(parameters['360multi_output_dir'], ctdirs_rel_paths[i]), dax[i], cra[i])
 

--- a/tofu/ez/Helpers/stitch_funcs.py
+++ b/tofu/ez/Helpers/stitch_funcs.py
@@ -147,14 +147,22 @@ def main_sti_mp():
     elif len(vert_sets) > 1:
         print(" - Working with several CT directories which contain multiple vertical views")
 
+    keep_tmp_dir = EZVARS['inout']['keep-tmp']['value']
+    tmp_root_dir = EZVARS_aux['vert-sti']['tmp-dir']['value']
     for vert_set in vert_sets:
         ctdir = os.path.relpath(vert_set, start=EZVARS_aux['vert-sti']['input-dir']['value'])
         print(f"-> Working on {str(ctdir)} dataset")
-        tmpdir = os.path.join(EZVARS_aux['vert-sti']['tmp-dir']['value'], ctdir)
+        tmpdir = os.path.join(tmp_root_dir, ctdir)
         outdir = os.path.join(EZVARS_aux['vert-sti']['output-dir']['value'], ctdir)
         if not os.path.exists(outdir):
             os.makedirs(outdir)
         stitch_func(vert_set, tmpdir, outdir)
+        if not keep_tmp_dir and os.path.isdir(tmpdir):
+            if os.path.samefile(tmp_root_dir, tmpdir):
+                for dir in os.listdir(tmp_root_dir):
+                    shutil.rmtree(os.path.join(tmp_root_dir, dir))
+            else:
+                shutil.rmtree(tmpdir)
 
 
 def sti_one_set(in_dir_path, tmp_dir_path, out_dir_path):

--- a/tofu/ez/Helpers/stitch_funcs.py
+++ b/tofu/ez/Helpers/stitch_funcs.py
@@ -404,7 +404,7 @@ def main_360sti_ufol_depth1(indir, outdir, ax, cro,
         if im.dtype == 'uint8':
             bits = 8
         elif im.dtype == 'uint16':
-            bits = 16,
+            bits = 16
         outpath = os.path.join(outdir, sdir)
         cmd = fmt_stitch_cmd(inpath, bigtiff, bits, outpath, numpairs, w, ax, cro, current_reduction_mode)
         #print(cmd)

--- a/tofu/ez/Helpers/stitch_funcs.py
+++ b/tofu/ez/Helpers/stitch_funcs.py
@@ -8,7 +8,8 @@ import os
 import shutil
 import numpy as np
 import tifffile
-from tofu.util import read_image, get_image_shape, get_filenames, TiffSequenceReader, SequenceReaderError
+from tofu.util import read_image, get_image_shape, TiffSequenceReader, SequenceReaderError, \
+    get_first_filename
 from tofu.ez.util import get_data_cube_info, add_value_to_dict_entry, get_dims
 from tofu.ez.image_read_write import get_image_dtype
 import multiprocessing as mp
@@ -401,10 +402,7 @@ def main_360_mp_depth2():
               f"180-deg parallel-beam scans")
         return
 
-    tmp = len(EZVARS_aux['stitch360']['input-dir']['value'])
-    ctdirs_rel_paths = []
-    for i in range(num_sets):
-        ctdirs_rel_paths.append(ctdirs[i][tmp+1:len(ctdirs[i])])
+    ctdirs_rel_paths = [os.path.relpath(ctdir, start=EZVARS_aux['stitch360']['input-dir']['value']) for ctdir in ctdirs]
     print(f"Found the {num_sets} directories in the input with relative paths: {ctdirs_rel_paths}")
 
     # make_ort_sections axis and crop arrays
@@ -420,9 +418,8 @@ def main_360_mp_depth2():
     # compute crop:
     cra = np.max(dax)-dax
     # Axis on the right ? Must open one file to find out ><
-    tmpname = os.path.join(EZVARS_aux['stitch360']['input-dir']['value'], ctdirs_rel_paths[0])
-    subdirs = sorted_sub_directories(tmpname)
-    M = get_image_shape(get_filenames(os.path.join(tmpname, subdirs[0]))[0])[-1]
+    first_tomo_dir = os.path.join(ctdirs[0], EZVARS['inout']['tomo-dir']['value'])
+    M = get_image_shape(get_first_filename(first_tomo_dir))[-1]
     if np.min(dax) > M//2:
         cra = dax - np.min(dax)
     print(f'Crop by: {cra}')

--- a/tofu/ez/Helpers/stitch_funcs.py
+++ b/tofu/ez/Helpers/stitch_funcs.py
@@ -384,6 +384,19 @@ def main_360sti_ufol_depth1(indir, outdir, ax, cro):
         os.system(cmd)
 
 
+def compute_crop(dax, image_shape):
+    """Compute the crop values required to output matching image widths after stitching
+
+    Required for vertical stitching after reconstruction.
+
+    Returns a sequence of crop values the same length as dax
+    """
+    cra = np.max(dax) - dax
+    M = image_shape[-1]
+    if np.min(dax) > M//2:
+        cra = dax - np.min(dax)
+    return cra
+
 def main_360_mp_depth2():
     ctdirs, lvl0 = findCTdirs(EZVARS_aux['stitch360']['input-dir']['value'],
                                 EZVARS['inout']['tomo-dir']['value'])
@@ -416,12 +429,10 @@ def main_360_mp_depth2():
             dax[i] = int(dax[i])
     print(f'Overlaps: {dax}')
     # compute crop:
-    cra = np.max(dax)-dax
     # Axis on the right ? Must open one file to find out ><
     first_tomo_dir = os.path.join(ctdirs[0], EZVARS['inout']['tomo-dir']['value'])
-    M = get_image_shape(get_first_filename(first_tomo_dir))[-1]
-    if np.min(dax) > M//2:
-        cra = dax - np.min(dax)
+    image_shape = get_image_shape(get_first_filename(first_tomo_dir))
+    cra = compute_crop(dax, image_shape)
     print(f'Crop by: {cra}')
 
     for i, ctdir in enumerate(ctdirs):

--- a/tofu/ez/ctdir_walker.py
+++ b/tofu/ez/ctdir_walker.py
@@ -186,3 +186,24 @@ class WalkCTdirs:
 
     def Getlvl0(self):
         return self.lvl0
+
+
+def substitute_shared_flatsdarks() -> dict[str, str]:
+    """
+    Return a dictionary with structure {"flats": "/path/to/shared/flats"}
+    which respects EZVARS settings
+    """
+    substitutes = {}
+    if EZVARS['inout']['shared-flatsdarks']['value']:
+        for type in ['darks', 'flats', 'flats2']:
+            if type == 'flats2' and not EZVARS['inout']['shared-flats-after']['value']:
+                continue
+            key = f'path2-shared-{type}'
+            path = EZVARS['inout'][key]['value']
+            if not os.path.exists(path):
+                print(f"Shared {type} not found: {path}")
+                continue
+            name = EZVARS['inout'][f'{type}-dir']['value']
+            substitutes[name] = path
+
+    return substitutes

--- a/tofu/ez/find_axis_cmd_gen.py
+++ b/tofu/ez/find_axis_cmd_gen.py
@@ -13,15 +13,15 @@ from tofu.ez.params import EZVARS
 from tofu.config import SECTIONS
 from tofu.ez.tofu_cmd_gen import check_lamino, gpu_optim
 
-def find_axis_std(ctset, tmpdir, ax_range, p_width, nviews, wh):
+def find_axis_std(ctset, tmpdir, ax_range, p_width, nviews, wh, reduction_mode="median"):
     indir = make_inpaths(ctset[0], ctset[1])
     cmd = 'tofu reco'
     if EZVARS['advanced']['more-reco-params']['value'] is True:
         cmd += check_lamino()
     elif EZVARS['advanced']['more-reco-params']['value'] is False:
         cmd += " --overall-angle 180"
-    cmd += " --darks {} --flats {} --reduction-mode median --projections {}".format(
-        indir[0], indir[1], enquote(indir[2])
+    cmd += " --darks {} --flats {} --reduction-mode {} --projections {}".format(
+        indir[0], indir[1], reduction_mode, enquote(indir[2])
     )
     cmd += " --number {}".format(nviews)
     if EZVARS['COR']['min-std-apply-pr']['value']:

--- a/tofu/ez/main.py
+++ b/tofu/ez/main.py
@@ -68,7 +68,7 @@ def get_CTdirs_list(inpath, fdt_names):
         return W.ctsets, W.lvl0
 
 
-def frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass):
+def frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass, reduction_mode="median"):
     """formats list of processing commands for a CT set"""
     # two helper variables to note that PR/FFC has been done at some step
     swiFFC = True  # FFC is always required
@@ -102,7 +102,7 @@ def frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass):
         cmds.append('echo " - Creating mask of large bad spots in flat field"')
         cmds.append(get_find_spots_cmd(EZVARS['inout']['tmp-dir']['value']))
         cmds.append('echo " - Flat-correcting and removing large spots"')
-        cmds_inpaint = get_inp_cmd(ctset, EZVARS['inout']['tmp-dir']['value'], wh[0], nviews)
+        cmds_inpaint = get_inp_cmd(ctset, EZVARS['inout']['tmp-dir']['value'], wh[0], nviews, reduction_mode=reduction_mode)
         # reset location of input data
         ctset = (EZVARS['inout']['tmp-dir']['value'], ctset[1])
         cmds.extend(cmds_inpaint)
@@ -116,10 +116,10 @@ def frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass):
         if swiFFC:  # we still need need flat correction #Inpaint No
             cmds.append('echo " - Phase retrieval with flat-correction"')
             if EZVARS['flat-correction']['smart-ffc']['value']:
-                cmds.append(get_pr_sinFFC_cmd(ctset))
+                cmds.append(get_pr_sinFFC_cmd(ctset, reduction_mode=reduction_mode))
                 cmds.append(get_pr_tofu_cmd_sinFFC(ctset))
             elif not EZVARS['flat-correction']['smart-ffc']['value']:
-                cmds.append(get_pr_tofu_cmd(ctset))
+                cmds.append(get_pr_tofu_cmd(ctset, reduction_mode=reduction_mode))
         else:  # Inpaint Yes
             cmds.append('echo " - Phase retrieval from flat-corrected projections"')
             cmds.extend(get_pr_ufo_cmd(nviews, wh))
@@ -132,14 +132,14 @@ def frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass):
         if swiFFC:  # we still need to do flat-field correction
             if EZVARS['flat-correction']['smart-ffc']['value']:
                 # Create flat corrected images using sinFFC
-                cmds.append(get_sinFFC_cmd(ctset))
+                cmds.append(get_sinFFC_cmd(ctset, reduction_mode=reduction_mode))
                 # Feed the flat corrected images to sino gram generation
                 cmds.append(get_sinos_noffc_cmd(ctset[0], EZVARS['inout']['tmp-dir']['value'],
                                                 nviews, wh, n_per_pass))
             elif not EZVARS['flat-correction']['smart-ffc']['value']:
                 cmds.append('echo " - Make sinograms with flat-correction"')
                 cmds.append(get_sinos_ffc_cmd(ctset, EZVARS['inout']['tmp-dir']['value'],
-                                              nviews, wh, n_per_pass))
+                                              nviews, wh, n_per_pass, reduction_mode=reduction_mode))
         else:  # we do not need flat-field correction
             cmds.append('echo " - Make sinograms without flat-correction"')
             cmds.append(get_sinos_noffc_cmd(ctset[0], EZVARS['inout']['tmp-dir']['value'],
@@ -184,10 +184,10 @@ def frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass):
     # Finally - call to tofu reco
     cmds.append('echo " - CT with axis {}; ffc:{}, PR:{}"'.format(ax, swiFFC, swiPR))
     if EZVARS['flat-correction']['smart-ffc']['value'] and swiFFC:
-        cmds.append(get_sinFFC_cmd(ctset))
-        cmds.append(get_reco_cmd(ctset, out_pattern, ax, nviews, wh, False, swiPR))
+        cmds.append(get_sinFFC_cmd(ctset, reduction_mode=reduction_mode))
+        cmds.append(get_reco_cmd(ctset, out_pattern, ax, nviews, wh, False, swiPR, reduction_mode=reduction_mode))
     else:  # If not using sinFFC
-        cmds.append(get_reco_cmd(ctset, out_pattern, ax, nviews, wh, swiFFC, swiPR))
+        cmds.append(get_reco_cmd(ctset, out_pattern, ax, nviews, wh, swiFFC, swiPR, reduction_mode=reduction_mode))
 
     return nviews, wh
 
@@ -202,6 +202,8 @@ def execute_reconstruction():
     if EZVARS['inout']['clip_hist']['value']:
         if SECTIONS['general']['output-minimum']['value'] > SECTIONS['general']['output-maximum']['value']:
             raise ValueError('hmin must be smaller than hmax to convert to 8bit without contrast inversion')
+
+    reduction_mode = EZVARS['flat-correction']['reduction-mode']['value']
 
     # get list of all good CT directories to be reconstructed
 
@@ -300,7 +302,7 @@ def execute_reconstruction():
                                         os.path.join(EZVARS['inout']['output-dir']['value'], setid),
                                         EZVARS['COR']['search-interval']['value'],
                                         EZVARS['COR']['patch-size']['value'],
-                                        nviews, wh)
+                                        nviews, wh, reduction_mode=reduction_mode)
                 else:
                     ax = axlist[i]#EZVARS['COR']['user-defined-ax']['value'] + i * EZVARS['COR']['user-defined-dax']['value']
             # If EZVARS['COR']['search-method']['value'] >= 4 then bypass axis search and use image midpoint
@@ -317,7 +319,7 @@ def execute_reconstruction():
             cmds.append('echo "Cleaning temporary directory"'.format(setid))
             clean_tmp_dirs(EZVARS['inout']['tmp-dir']['value'], fdt_names)
             # call function which formats commands for this data set
-            nviews, wh = frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass)
+            nviews, wh = frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass, reduction_mode=reduction_mode)
             save_params(setid, ax, nviews, wh)
             print('{}\t{}'.format('CTset:', ctset[0]))
             print('{:>30}\t{}'.format('Axis:', ax))

--- a/tofu/ez/main.py
+++ b/tofu/ez/main.py
@@ -19,7 +19,7 @@ from tofu.ez.params import EZVARS
 from tofu.config import SECTIONS
 from tofu.ez.Helpers.batch_search_stitch_360 import batch_stitch, batch_olap_search
 from tofu.ez.Helpers.stitch_funcs import find_vert_olap_2_vsteps, main_sti_mp, \
-    complete_message, find_depth_level_to_CT_sets, validate_slice_range
+    complete_message, validate_slice_range
 from shutil import rmtree
 
 LOG = logging.getLogger(__name__)
@@ -353,8 +353,8 @@ def execute_reconstruction():
         # validate slice range (common problem)
         try:
             validate_slice_range()
-        except ValueError as e:
-            print(f"Cannot format path to a directory with slices. Check directory structure")
+        except Exception as e:
+            print(f"Cannot validate slice range for vertical stitching. Check directory structure")
             LOG.error(e)
         else:
             main_sti_mp()

--- a/tofu/ez/main.py
+++ b/tofu/ez/main.py
@@ -214,6 +214,7 @@ def execute_reconstruction():
 
     # if we deal with unstitched half acqusition mode data we have to
     # convert all frames to ordinary 180-deg projections first
+    shared_flatsdarks_orig_value = None
     if EZVARS['COR']['search-method']['value'] == 5:
         if EZVARS_aux['half-acq']['task_type']['value']: # task_type=1 meaning overlaps must be estimated first
             print('# +++++++++++++++++++++++++++++++++++++++++++++++')
@@ -233,6 +234,12 @@ def execute_reconstruction():
             print(f"Something went wrong with stitching of half acq mode data "
                   "examine output for errors")
             return
+        # Disable shared-flatsdarks as the stitched versions are now present in each
+        # stitched-data ctset
+        shared_flatsdarks_orig_value = EZVARS['inout']['shared-flatsdarks']['value']
+        if shared_flatsdarks_orig_value is True:
+            add_value_to_dict_entry(EZVARS['inout']['shared-flatsdarks'], False)
+
         # at this point we have stitched projections in working directory for batch 360
         # so we get CT sets from this directory instead of the original input
         W, lvl0 = get_CTdirs_list(os.path.join(
@@ -343,7 +350,8 @@ def execute_reconstruction():
             print(cmd)
     if not EZVARS['inout']['keep-tmp']['value']:
         clean_tmp_dirs(EZVARS['inout']['tmp-dir']['value'], fdt_names)
-
+    if shared_flatsdarks_orig_value and shared_flatsdarks_orig_value != EZVARS['inout']['shared-flatsdarks']['value']:
+        add_value_to_dict_entry(EZVARS['inout']['shared-flatsdarks'], shared_flatsdarks_orig_value)
     print("========================================")
     if EZVARS_aux['vert-sti']['dovertsti']['value']:
         print("======= Begin Vertical Stitching =======")

--- a/tofu/ez/main.py
+++ b/tofu/ez/main.py
@@ -20,7 +20,6 @@ from tofu.config import SECTIONS
 from tofu.ez.Helpers.batch_search_stitch_360 import batch_stitch, batch_olap_search
 from tofu.ez.Helpers.stitch_funcs import find_vert_olap_2_vsteps, main_sti_mp, \
     complete_message, validate_slice_range
-from shutil import rmtree
 
 LOG = logging.getLogger(__name__)
 
@@ -358,10 +357,6 @@ def execute_reconstruction():
             LOG.error(e)
         else:
             main_sti_mp()
-            if not EZVARS['inout']['keep-tmp']['value']:
-                vert_sti_tmp = EZVARS_aux['vert-sti']['tmp-dir']['value']
-                for dir in os.listdir(vert_sti_tmp):
-                    rmtree(os.path.join(vert_sti_tmp, dir))
 
     print("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
     if (EZVARS['COR']['search-method']['value'] == 5) and EZVARS_aux['vert-sti']['dovertsti']['value']:

--- a/tofu/ez/main.py
+++ b/tofu/ez/main.py
@@ -87,7 +87,8 @@ def frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass, reductio
             path2flat = os.path.join(ctset[0],
                                      EZVARS['inout']['path2-shared-flats']['value'])
         medflat_file = os.path.join(EZVARS['inout']['tmp-dir']['value'], "flat-median.tif")
-        imwrite(medflat_file, get_median_flat(path2flat))
+        script_str = "import sys; from tifffile import imwrite; from tofu.ez.util import get_median_flat; imwrite(sys.argv[1], get_median_flat(sys.argv[2]))"
+        cmds.append(f'python -c \'{script_str}\' "{medflat_file}" "{path2flat}"')
     if EZVARS['inout']['preprocess']['value']:
         cmds.append('echo " - Applying filter(s) to images "')
         cmds_prepro = get_pre_cmd(ctset, EZVARS['inout']['preprocess-command']['value'],

--- a/tofu/ez/main.py
+++ b/tofu/ez/main.py
@@ -328,6 +328,7 @@ def execute_reconstruction():
             args_str = " ".join(f'"{name}"' for name in fdt_names)
             cmds.append(f'python -c \'{script_str}\' "{EZVARS["inout"]["tmp-dir"]["value"]}" {args_str}')
             # call function which formats commands for this data set
+            reset_proj_steps()
             nviews, wh = frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass, reduction_mode=reduction_mode)
             save_params(setid, ax, nviews, wh)
             print('{}\t{}'.format('CTset:', ctset[0]))

--- a/tofu/ez/main.py
+++ b/tofu/ez/main.py
@@ -217,7 +217,7 @@ def execute_reconstruction():
     shared_flatsdarks_orig_value = None
     if EZVARS['COR']['search-method']['value'] == 5:
         if EZVARS_aux['half-acq']['task_type']['value']: # task_type=1 meaning overlaps must be estimated first
-            print('# +++++++++++++++++++++++++++++++++++++++++++++++')
+            print('# +++++++++++++++++++++++++++++++++++++++++++++++', flush=True)
             print('# Estimating overlaps for half acq mode data sets')
             print('# +++++++++++++++++++++++++++++++++++++++++++++++')
             if batch_olap_search():
@@ -227,7 +227,7 @@ def execute_reconstruction():
                                        'ezvars_aux_from_overlap_search.yaml' ), ['ezvars_aux'])
         # at this point we are ready to stitch projections
         #list of overlaps is in the EZVARS_aux['axes-list']
-        print('# +++++++++++++++++++++++++++++++++++++++++++++++')
+        print('# +++++++++++++++++++++++++++++++++++++++++++++++', flush=True)
         print("# Batch stitching half acq mode data sets")
         print('# +++++++++++++++++++++++++++++++++++++++++++++++')
         if batch_stitch():
@@ -249,7 +249,7 @@ def execute_reconstruction():
     # get list of already reconstructed sets
     recd_sets = findSlicesDirs(EZVARS['inout']['output-dir']['value'])
     # find axis of rotation and populate list of reconstruction commands
-    print("*********** AXIS INFO ************")
+    print("*********** AXIS INFO ************", flush=True)
     # if axis is defined by user then make appropriate list
     if EZVARS['COR']['search-method']['value'] == 3:
         axlist = EZVARS['COR']['user-defined-ax']['value'].split(',')
@@ -342,7 +342,7 @@ def execute_reconstruction():
             print("{} has been already reconstructed".format(ctset[0]))
     # execute commands = start reconstruction
     start = time.time()
-    print("*********** PROCESSING ************")
+    print("*********** PROCESSING ************", flush=True)
     for cmd in cmds:
         if not EZVARS['inout']['dryrun']['value']:
             os.system(cmd)
@@ -354,7 +354,7 @@ def execute_reconstruction():
         add_value_to_dict_entry(EZVARS['inout']['shared-flatsdarks'], shared_flatsdarks_orig_value)
     print("========================================")
     if EZVARS_aux['vert-sti']['dovertsti']['value']:
-        print("======= Begin Vertical Stitching =======")
+        print("======= Begin Vertical Stitching =======", flush=True)
         add_value_to_dict_entry(EZVARS_aux['vert-sti']['input-dir'],
                                 EZVARS['inout']['output-dir']['value'])
         # validate slice range (common problem)

--- a/tofu/ez/main.py
+++ b/tofu/ez/main.py
@@ -322,8 +322,10 @@ def execute_reconstruction():
             # rm files in temporary directory first of all to
             # format paths correctly and to avoid problems
             # when reconstructing ct sets with variable number of rows or projections
-            cmds.append('echo "Cleaning temporary directory"'.format(setid))
-            clean_tmp_dirs(EZVARS['inout']['tmp-dir']['value'], fdt_names)
+            cmds.append('echo "Cleaning temporary directory"')
+            script_str = "import sys; from tofu.ez.util import clean_tmp_dirs; clean_tmp_dirs(sys.argv[1], sys.argv[2:])"
+            args_str = " ".join(f'"{name}"' for name in fdt_names)
+            cmds.append(f'python -c \'{script_str}\' "{EZVARS["inout"]["tmp-dir"]["value"]}" {args_str}')
             # call function which formats commands for this data set
             nviews, wh = frmt_ufo_cmds(cmds, ctset, out_pattern, ax, nviews, wh, n_per_pass, reduction_mode=reduction_mode)
             save_params(setid, ax, nviews, wh)

--- a/tofu/ez/params.py
+++ b/tofu/ez/params.py
@@ -460,7 +460,7 @@ EZVARS['flat-correction'] = {
         'type': float, 
         'help': "Scaling falt"}, #(?) has the same name in SECTION
     'reduction-mode': {
-        'ezdefault': "median",
+        'ezdefault': "average",
         'type': str,
         'help': "Reduction mode for dark/flat fields: median or average"},
 }

--- a/tofu/ez/params.py
+++ b/tofu/ez/params.py
@@ -459,6 +459,10 @@ EZVARS['flat-correction'] = {
         'ezdefault': 1.0,
         'type': float, 
         'help': "Scaling falt"}, #(?) has the same name in SECTION
+    'reduction-mode': {
+        'ezdefault': "median",
+        'type': str,
+        'help': "Reduction mode for dark/flat fields: median or average"},
 }
 
 #TODO ADD CHECKING NLMDN SETTINGS

--- a/tofu/ez/tofu_cmd_gen.py
+++ b/tofu/ez/tofu_cmd_gen.py
@@ -239,7 +239,7 @@ def get_pr_tofu_cmd_sinFFC(ctset):
     cmd += ' --projection-crop-after filter'
     return cmd
 
-def get_pr_tofu_cmd(ctset):
+def get_pr_tofu_cmd(ctset, reduction_mode="median"):
     # indir will format paths to flats darks and tomo2 correctly even if they were
     # pre-processed, however path to the input directory with projections
     # cannot be formatted with that command correctly
@@ -249,7 +249,7 @@ def get_pr_tofu_cmd(ctset):
                                                ctset[0], EZVARS['inout']['tomo-dir']['value'])
     flats2_dir = indir[3] if ctset[1] == 4 else None
 
-    return fmt_pr_cmd(indir[0], indir[1], in_proj_dir, flats2_dir, out_pattern)
+    return fmt_pr_cmd(indir[0], indir[1], in_proj_dir, flats2_dir, out_pattern, reduction_mode=reduction_mode)
 
 def fmt_pr_cmd(darks_dir, flats_dir, tomo_dir, flats2_dir, out_pattern, reduction_mode="median"):
     cmd = 'tofu preprocess --fix-nan-and-inf --projection-filter none --delta 1e-6'

--- a/tofu/ez/tofu_cmd_gen.py
+++ b/tofu/ez/tofu_cmd_gen.py
@@ -58,7 +58,7 @@ def check_bigtif(cmd, swi):
         cmd += " --output-bytes-per-file 0"
     return cmd
 
-def get_1step_ct_cmd(ctset, out_pattern, ax, nviews, wh):
+def get_1step_ct_cmd(ctset, out_pattern, ax, nviews, wh, reduction_mode="median"):
     # direct CT reconstruction from input dir to output dir;
     # obsolete, replaced by tofu reco, see get_reco_cmd() lower
     indir = make_inpaths(ctset[0], ctset[1])
@@ -68,7 +68,7 @@ def get_1step_ct_cmd(ctset, out_pattern, ax, nviews, wh):
     indir[2] = os.path.join(os.path.split(indir[2])[0], os.path.split(in_proj_dir)[1])
     # format command
     cmd = "tofu tomo --absorptivity --fix-nan-and-inf"
-    cmd += " --darks {} --flats {} --reduction-mode median --projections {}".format(indir[0], indir[1], indir[2])
+    cmd += " --darks {} --flats {} --reduction-mode {} --projections {}".format(indir[0], indir[1], reduction_mode, indir[2])
     if ctset[1] == 4:  # must be equivalent to len(indir)>3
         cmd += " --flats2 {}".format(indir[3])
     cmd += " --output {}".format(out_pattern)
@@ -131,12 +131,12 @@ def get_ct_sin_cmd(out_pattern, ax, nviews, wh):
     cmd = check_bigtif(cmd, EZVARS['inout']['bigtiff-output']['value'])
     return cmd
 
-def get_sinos_ffc_cmd(ctset, tmpdir, nviews, wh, n_per_pass):
+def get_sinos_ffc_cmd(ctset, tmpdir, nviews, wh, n_per_pass, reduction_mode="median"):
     indir = make_inpaths(ctset[0], ctset[1])
     in_proj_dir, out_pattern = fmt_in_out_path(EZVARS['inout']['tmp-dir']['value'],
                                     ctset[0], EZVARS['inout']['tomo-dir']['value'], False)
     cmd = 'tofu sinos --absorptivity --fix-nan-and-inf'
-    cmd += ' --darks {} --flats {} --reduction-mode median '.format(indir[0], indir[1])
+    cmd += ' --darks {} --flats {} --reduction-mode {} '.format(indir[0], indir[1], reduction_mode)
     if ctset[1] == 4:
         cmd += " --flats2 {}".format(indir[3])
     cmd += " --projections {}".format(in_proj_dir)
@@ -186,12 +186,12 @@ def get_sinos2proj_cmd(proj_height, n_per_pass):
     cmd += f" --pass-size {n_per_pass}"
     return cmd
 
-def get_sinFFC_cmd(ctset):
+def get_sinFFC_cmd(ctset, reduction_mode="median"):
     indir = make_inpaths(ctset[0], ctset[1])
     in_proj_dir, out_pattern = fmt_in_out_path(EZVARS['inout']['tmp-dir']['value'],
                                                ctset[0], EZVARS['inout']['tomo-dir']['value'])
     cmd = 'bmit_sin --fix-nan'
-    cmd += ' --darks {} --flats {} --reduction-mode median --projections {}'.format(indir[0], indir[1], in_proj_dir)
+    cmd += ' --darks {} --flats {} --reduction-mode {} --projections {}'.format(indir[0], indir[1], reduction_mode, in_proj_dir)
     if ctset[1] == 4:
         cmd += ' --flats2 {}'.format(indir[3])
     cmd += ' --output {}'.format(os.path.dirname(out_pattern))
@@ -202,12 +202,12 @@ def get_sinFFC_cmd(ctset):
     cmd += ' --downsample {}'.format(EZVARS['flat-correction']['downsample']['value'])
     return cmd
 
-def get_pr_sinFFC_cmd(ctset):
+def get_pr_sinFFC_cmd(ctset, reduction_mode="median"):
     indir = make_inpaths(ctset[0], ctset[1])
     in_proj_dir, out_pattern = fmt_in_out_path(
         EZVARS['inout']['tmp-dir']['value'], ctset[0], EZVARS['inout']['tomo-dir']['value'])
     cmd = 'bmit_sin --fix-nan'
-    cmd += ' --darks {} --flats {} --reduction-mode median --projections {}'.format(indir[0], indir[1], in_proj_dir)
+    cmd += ' --darks {} --flats {} --reduction-mode {} --projections {}'.format(indir[0], indir[1], reduction_mode, in_proj_dir)
     if ctset[1] == 4:
         cmd += ' --flats2 {}'.format(indir[3])
     cmd += ' --output {}'.format(os.path.dirname(out_pattern))
@@ -251,10 +251,10 @@ def get_pr_tofu_cmd(ctset):
 
     return fmt_pr_cmd(indir[0], indir[1], in_proj_dir, flats2_dir, out_pattern)
 
-def fmt_pr_cmd(darks_dir, flats_dir, tomo_dir, flats2_dir, out_pattern):
+def fmt_pr_cmd(darks_dir, flats_dir, tomo_dir, flats2_dir, out_pattern, reduction_mode="median"):
     cmd = 'tofu preprocess --fix-nan-and-inf --projection-filter none --delta 1e-6'
-    cmd += ' --darks {} --flats {} --reduction-mode median --projections {}'.\
-                format(darks_dir, flats_dir, tomo_dir)
+    cmd += ' --darks {} --flats {} --reduction-mode {} --projections {}'.\
+                format(darks_dir, flats_dir, reduction_mode, tomo_dir)
     if flats2_dir:
         cmd += ' --flats2 {}'.format(flats2_dir)
     cmd += ' --output {}'.format(out_pattern)
@@ -267,7 +267,7 @@ def fmt_pr_cmd(darks_dir, flats_dir, tomo_dir, flats2_dir, out_pattern):
     cmd += ' --flat-scale {}'.format(EZVARS['flat-correction']['flat-scale']['value'])
     return cmd
 
-def get_reco_cmd(ctset, out_pattern, ax, nviews, wh, ffc, pr):
+def get_reco_cmd(ctset, out_pattern, ax, nviews, wh, ffc, pr, reduction_mode="median"):
     # direct CT reconstruction from input dir to output dir;
     # or CT reconstruction after preprocessing only
     indir = make_inpaths(ctset[0], ctset[1])
@@ -285,7 +285,7 @@ def get_reco_cmd(ctset, out_pattern, ax, nviews, wh, ffc, pr):
     cmd += ' --output {}'.format(out_pattern)
     if ffc:
         cmd += ' --fix-nan-and-inf'
-        cmd += ' --darks {} --flats {} --reduction-mode median'.format(indir[0], indir[1])
+        cmd += ' --darks {} --flats {} --reduction-mode {}'.format(indir[0], indir[1], reduction_mode)
         if ctset[1] == 4:  # must be equivalent to len(indir)>3
             cmd += ' --flats2 {}'.format(indir[3])
         if not pr:

--- a/tofu/ez/tofu_cmd_gen.py
+++ b/tofu/ez/tofu_cmd_gen.py
@@ -8,7 +8,7 @@ import numpy as np
 from tofu.ez.ufo_cmd_gen import fmt_in_out_path
 from tofu.ez.params import EZVARS
 from tofu.config import SECTIONS
-from tofu.ez.util import make_inpaths, fmt_in_out_path, get_data_cube_info
+from tofu.ez.util import make_inpaths, fmt_in_out_path
 
 
 # TODO: check amount of RAM and generate sinograms in multiple passes if needed

--- a/tofu/ez/ufo_cmd_gen.py
+++ b/tofu/ez/ufo_cmd_gen.py
@@ -115,7 +115,7 @@ def get_pre_cmd( ctset, pre_cmd, tmpdir):
         cmds[i] += " ! write filename={}".format(enquote(out_pattern))
     return cmds
 
-def get_inp_cmd(ctset, tmpdir, N, nviews):
+def get_inp_cmd(ctset, tmpdir, N, nviews, reduction_mode="median"):
     indir = make_inpaths(ctset[0], ctset[1])
     cmds = []
     # ######### CREATE MASK #########
@@ -154,7 +154,7 @@ def get_inp_cmd(ctset, tmpdir, N, nviews):
         cmds.append(cmd)
     elif not EZVARS['flat-correction']['smart-ffc']['value']:
         cmd = 'tofu flatcorrect --fix-nan-and-inf'
-        cmd += ' --darks {} --flats {} --reduction-mode median'.format(indir[0], indir[1])
+        cmd += ' --darks {} --flats {} --reduction-mode {}'.format(indir[0], indir[1], reduction_mode)
         cmd += ' --projections {}'.format(in_proj_dir)
         cmd += ' --output {}'.format(out_pattern)
         if ctset[1] == 4:

--- a/tofu/ez/ufo_cmd_gen.py
+++ b/tofu/ez/ufo_cmd_gen.py
@@ -212,7 +212,7 @@ def fmt_nlmdn_ufo_cmd(inpath: str, outpath: str):
         cmd += f" bits={SECTIONS['general']['output-bitdepth']['value']} rescale=False"
     return cmd
 
-def fmt_stitch_cmd(inpath, bigtiff, bits, outpath, num, w, ax, cro=0):
+def fmt_stitch_cmd(inpath, bigtiff, bits, outpath, num, w, ax, cro=0, reduction_mode=None):
     cmd = 'ufo-launch'
     st = 'start'
     if bigtiff:
@@ -222,13 +222,21 @@ def fmt_stitch_cmd(inpath, bigtiff, bits, outpath, num, w, ax, cro=0):
         # Single image treated as a pair (darks / flats)
         start = 0
         num = 1
+    set_1 = f"read path={inpath} {st}={start} number={num}"
+    set_2 = f"read path={inpath} number={num}"
+    if reduction_mode == 'average':
+        set_2 = set_2 + " ! average"
+        set_1 = set_2
+    elif reduction_mode == 'median':
+        set_2 = set_2 + f" ! stack number={num} ! flatten mode=median"
+        set_1 = set_2
     if ax <= w // 2:
-        cmd += f" [read path={inpath} {st}={start} number={num} ! flip," \
-                f" read path={inpath} number={num}]" \
+        cmd += f" [{set_1} ! flip," \
+                f" {set_2}]" \
                 f" ! stitch shift={w - 2*ax}"
     else:
-        cmd += f" [read path={inpath} number={num} ! flip,"\
-               f" read path={inpath} {st}={start} number={num}]" \
+        cmd += f" [{set_2} ! flip,"\
+               f" {set_1}]" \
                f" ! stitch shift={w - 2*ax}"
         ax = w - ax
     cmd += " blend=True adjust-mean=TRUE !"

--- a/tofu/ez/ufo_cmd_gen.py
+++ b/tofu/ez/ufo_cmd_gen.py
@@ -217,13 +217,18 @@ def fmt_stitch_cmd(inpath, bigtiff, bits, outpath, num, w, ax, cro=0):
     st = 'start'
     if bigtiff:
         st = 'image-start'
+    start = num
+    if num == 0:
+        # Single image treated as a pair (darks / flats)
+        start = 0
+        num = 1
     if ax <= w // 2:
-        cmd += f" [read path={inpath} {st}={num} number={num} ! flip," \
+        cmd += f" [read path={inpath} {st}={start} number={num} ! flip," \
                 f" read path={inpath} number={num}]" \
                 f" ! stitch shift={w - 2*ax}"
     else:
         cmd += f" [read path={inpath} number={num} ! flip,"\
-               f" read path={inpath} {st}={num} number={num}]" \
+               f" read path={inpath} {st}={start} number={num}]" \
                f" ! stitch shift={w - 2*ax}"
         ax = w - ax
     cmd += " blend=True adjust-mean=TRUE !"

--- a/tofu/ez/util.py
+++ b/tofu/ez/util.py
@@ -4,6 +4,7 @@ Created on Apr 20, 2020
 @author: gasilos
 """
 import os, glob, tifffile
+import shutil
 
 from tofu.ez.ctdir_walker import VALID_EXTS
 from tofu.ez.params import EZVARS, EZVARS_aux
@@ -97,7 +98,11 @@ def clean_tmp_dirs(tmpdir, fdt_names):
     if os.path.exists(tmpdir):
         for filename in os.listdir(tmpdir):
             if filename[:4] in tmp_pattern:
-                os.system("rm -rf {}".format(os.path.join(tmpdir, filename)))
+                path = os.path.join(tmpdir, filename)
+                if os.path.isdir(path):
+                    shutil.rmtree(path)
+                else:
+                    os.remove(path)
 
 def make_inpaths(lvl0, flats2):
     """

--- a/tofu/ez/util.py
+++ b/tofu/ez/util.py
@@ -53,7 +53,7 @@ def get_data_cube_info(pth):
         bit = 32; dt = 'float32'
     ram_amount_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
     n_per_pass = int(0.9 * ram_amount_bytes / (N * M * 4))
-    return nslices, N, M, bit, dt, n_per_pass
+    return nslices, N, M, bit, dt, n_per_pass, ext
 
 def bad_vert_ROI(multipage, path2proj, y, height):
     if multipage:

--- a/tofu/ez/util.py
+++ b/tofu/ez/util.py
@@ -137,24 +137,32 @@ def make_inpaths(lvl0, flats2):
             add_value_to_dict_entry(EZVARS['inout']['shared-df-used'], True)
         return indir
 
+_PROJ_STEPS = 0
+
+def reset_proj_steps():
+    global _PROJ_STEPS
+    _PROJ_STEPS = 0
+
 def fmt_in_out_path(tmpdir, indir, raw_proj_dir_name, croutdir=True):
+    global _PROJ_STEPS
     # suggests input and output path to directory with proj
     # depending on number of processing steps applied so far
-    li = sorted(glob.glob(os.path.join(tmpdir, "proj-step*")))
-    proj_dirs = [d for d in li if os.path.isdir(d)]
-    Nsteps = len(proj_dirs)
-    in_proj_dir, out_proj_dir = "qqq", "qqq"
-    if Nsteps == 0:  # no projections in temporary directory
+    if _PROJ_STEPS == 0:  # no projections in temporary directory
         in_proj_dir = os.path.join(indir, raw_proj_dir_name)
-        out_proj_dir = os.path.join(tmpdir, "proj-step1")
-    elif Nsteps > 0:  # there are directories proj-stepX in tmp dir
-        in_proj_dir = proj_dirs[-1]
-        out_proj_dir = "{}{}".format(in_proj_dir[:-1], Nsteps + 1)
+    elif _PROJ_STEPS > 0:  # there are directories proj-stepX in tmp dir
+        in_proj_dir = os.path.join(tmpdir, f"proj-step{_PROJ_STEPS}")
     else:
         raise ValueError("Something is wrong with in/out filenames")
-    # physically create output directory
-    if croutdir and not os.path.exists(out_proj_dir):
-        os.makedirs(out_proj_dir)
+
+    out_step = _PROJ_STEPS + 1
+    out_proj_dir = os.path.join(tmpdir, f"proj-step{out_step}")
+
+    # create output directory and advance the pipeline step
+    if croutdir:
+        _PROJ_STEPS = out_step
+        if not os.path.exists(out_proj_dir):
+            os.makedirs(out_proj_dir)
+
     # return names of input directory and output pattern with abs path
     return in_proj_dir, os.path.join(out_proj_dir, "proj-%04i.tif")
 

--- a/tofu/ez/util.py
+++ b/tofu/ez/util.py
@@ -515,3 +515,6 @@ def get_fdt_names():
             EZVARS['inout']['flats-dir']['value'],
             EZVARS['inout']['tomo-dir']['value'],
             EZVARS['inout']['flats2-dir']['value']]
+
+def get_fd_names():
+    return tuple(EZVARS['inout'][f'{fd_type}-dir']['value'] for fd_type in ['darks', 'flats', 'flats2'])


### PR DESCRIPTION
*Note:* This PR includes changes from #153 #154 #156 and #158 (in that order).

~This is last one. Based on all the previous. If~ Since @sgasilov is okay with it, I'm fine to merge this one (and close the others and loose the distinct changeset history), or I can rebase the later ones for cleaner merging.

Here we found that the tmp-dir cleaning was only done during the cmd generation step, and not during execution. And so temporary files could leak into subsequent reconstructions unintentionally, which is especially problematic for halfacq datasets where the center of rotation moves slightly from one to the next.