### PR TITLE
Compress

### DIFF
--- a/bin/tofu
+++ b/bin/tofu
@@ -235,7 +235,7 @@ def main():
         ('interactive', run_shell,      tomo_params,                    "Run interactive mode"),
         ('find-large-spots', run_find_large_spots, ('find-large-spots',), "Find large spots on images"),
         ('inpaint',     run_inpaint,    ('inpaint',),                   "Inpaint images"),
-        ('compress',    run_compress,   ('compress',),                  "Compress images"),
+        ('compress',    run_compress,   ('compress', 'denoise'),        "Compress images"),
         ('decompress',  run_decompress, ('compress',),                  "Decompress images"),
         ('denoise',     run_denoise,    ('denoise',),                   "Denoise images"),
     ]

--- a/bin/tofu
+++ b/bin/tofu
@@ -236,7 +236,7 @@ def main():
         ('find-large-spots', run_find_large_spots, ('find-large-spots',), "Find large spots on images"),
         ('inpaint',     run_inpaint,    ('inpaint',),                   "Inpaint images"),
         ('compress',    run_compress,   ('compress',),                  "Compress images"),
-        ('decompress',  run_decompress, ('decompress',),                "Decompress images"),
+        ('decompress',  run_decompress, ('compress',),                  "Decompress images"),
         ('denoise',     run_denoise,    ('denoise',),                   "Denoise images"),
     ]
 

--- a/bin/tofu
+++ b/bin/tofu
@@ -116,6 +116,24 @@ def run_inpaint(args):
     inpaint.run(args)
 
 
+def run_compress(args):
+    from tofu import compress
+
+    compress.compress(args)
+
+
+def run_decompress(args):
+    from tofu import compress
+
+    compress.decompress(args)
+
+
+def run_denoise(args):
+    from tofu import denoise
+
+    denoise.denoise(args)
+
+
 def gui(args):
     try:
         from tofu import gui
@@ -217,6 +235,9 @@ def main():
         ('interactive', run_shell,      tomo_params,                    "Run interactive mode"),
         ('find-large-spots', run_find_large_spots, ('find-large-spots',), "Find large spots on images"),
         ('inpaint',     run_inpaint,    ('inpaint',),                   "Inpaint images"),
+        ('compress',    run_compress,   ('compress',),                  "Compress images"),
+        ('decompress',  run_decompress, ('decompress',),                "Decompress images"),
+        ('denoise',     run_denoise,    ('denoise',),                   "Denoise images"),
     ]
 
     if sys.version < '3.7':

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -194,7 +194,7 @@ epub_exclude_files = ['search.html']
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # -- Options for todo extension ----------------------------------------------
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -6,5 +6,6 @@ Usage
 
     usage/io
     usage/preprocessing
+    usage/postprocessing
     usage/genreco
     usage/flow

--- a/docs/source/usage/genreco.rst
+++ b/docs/source/usage/genreco.rst
@@ -19,6 +19,13 @@ scheme :cite:`Farago:tv5034`:
   :align: center
   :alt: 3D reconstruction geometry
 
+Output Denoising and Compression
+================================
+
+Reconstructed slices can be denoised with ``--denoise`` and companded into
+JPEG 2000-compressed TIFF output with ``--compress-output``. See
+:doc:`postprocessing` for the parameter requirements and an example.
+
 The dimensions are:
 
 - **x = lateral dimension**;

--- a/docs/source/usage/io.rst
+++ b/docs/source/usage/io.rst
@@ -42,6 +42,12 @@ string* e.g. ``output-%04d.tif``, which will create files ``output-0000.tif``,
 of bytes written in the current file would exceed the value specified by
 ``--output-bytes-per-file``.
 
+JPEG 2000-compressed TIFF input and output use all available CPU processors by
+default. The limits can be controlled independently with
+``--jpeg2000-threads`` for reading and ``--output-jpeg2000-threads`` for
+writing. A value of 0 uses all available processors and a value of 1 disables
+OpenJPEG worker parallelism.
+
 .. note::
    You may use ``k``, ``m``, ``g``, ``t`` suffixes with
    ``--output-bytes-per-file`` to indicate respectively kibibytes

--- a/docs/source/usage/postprocessing.rst
+++ b/docs/source/usage/postprocessing.rst
@@ -98,12 +98,20 @@ Denoising Before Compression
 when ``--denoise`` is specified. The denoising options are shared with
 ``tofu denoise``.
 
-The default denoising values follow the UFO filter constructor defaults:
+For standalone ``tofu denoise``, the default denoising values follow the UFO
+filter constructor defaults:
 
 - ``--denoise-h 0`` estimates the smoothing parameter from the first image;
 - ``--denoise-sigma 0`` leaves explicit noise compensation disabled, unless
   ``--denoise-estimate-sigma`` is also specified;
 - ``--denoise-estimate-sigma`` estimates ``sigma`` from the first image.
+
+For ``tofu compress --denoise``, if ``--denoise-h`` or ``--denoise-sigma`` are
+left at ``0``, Tofu sets the missing value from the compression setup and logs
+which value was used. If compression parameter estimation already calculated
+the input noise sigma, the denoising value is set to that sigma. Otherwise, it
+is set to ``--compress-delta``. Positive user-specified denoising values are
+left unchanged.
 
 For compression, ``--denoise-compression-aware`` sets both denoising scale
 parameters from the already determined compression spacing:

--- a/docs/source/usage/postprocessing.rst
+++ b/docs/source/usage/postprocessing.rst
@@ -1,0 +1,156 @@
+Post-processing
+===============
+
+Compression
+-----------
+
+``tofu compress`` stores reconstructed or otherwise processed images in a
+smaller representation. It first applies a reversible tone-mapping curve, then
+quantizes the result to an unsigned integer image, and finally writes the image
+through JPEG 2000 compression. ``tofu decompress`` applies the inverse mapping
+after JPEG 2000 decoding.
+
+This is useful when the data are floating point or have a wider useful dynamic
+range than the chosen output integer type. The compander keeps high precision
+near a chosen center value and spends less precision farther away from it.
+
+Tone Mapping
+~~~~~~~~~~~~
+
+The tone mapping step is controlled by ``--compress-compander``,
+``--compress-center``, ``--compress-delta`` and ``--compress-bits``.
+
+For an output bit depth of ``b``, the quantized dynamic range is
+:math:`D = 2^b - 1`. Each input grey value is normalized around
+``--compress-center`` and passed through a compander curve. The result is mapped
+from :math:`[-1, 1]` to :math:`[0, D]`.
+
+Available companders are:
+
+- ``tanh``: smooth saturation using a hyperbolic tangent;
+- ``arctan``: smooth saturation using an arctangent;
+- ``recip_sqrt``: smooth saturation using :math:`x / \sqrt{1 + x^2}`;
+- ``clip``: linear mapping near the center with hard clipping outside the range.
+
+``--compress-delta`` is the approximate input grey-value spacing represented by
+one output code near the center of the tone curve. Smaller values preserve
+finer differences near the center, but they spend the fixed output dynamic range
+more quickly. Larger values cover a wider input range, but quantization becomes
+coarser.
+
+.. figure:: ../figs/tone-mapping-curve-placeholder.svg
+   :alt: Placeholder for tone mapping curve explanation.
+   :align: center
+
+   Placeholder for a tone-mapping curve figure. The center line marks
+   ``--compress-center``. The soft and hard limits are useful landmarks for
+   judging how much of the data range is mapped nearly linearly and how much is
+   compressed into the saturating parts of the curve.
+
+Quantization
+~~~~~~~~~~~~
+
+After tone mapping, values are rounded to the smallest unsigned integer type
+that can hold the selected range: ``uint8`` for ``--compress-bits 8`` and
+``uint16`` for ``--compress-bits 16``.
+
+Quantization is lossy. The analysis step estimates this loss by compressing and
+expanding sample images and reporting the RMSE relative to the estimated noise
+sigma. A useful setting keeps quantization error clearly below the natural image
+noise, so that compression does not become the dominant degradation.
+
+JPEG 2000 Compression
+~~~~~~~~~~~~~~~~~~~~~
+
+The quantized companded image is then encoded with JPEG 2000. The option
+``--compress-j2k-rmse`` is specified in the original input grey-value units.
+Internally, Tofu converts it to the JPEG 2000 PSNR level using the physical
+range represented by the companded data:
+
+.. math::
+
+   \mathrm{PSNR} = 20 \log_{10}\left(\frac{\Delta D}{\mathrm{RMSE}}\right)
+
+where :math:`\Delta` is ``--compress-delta`` and :math:`D` is the quantized
+dynamic range.
+
+Like quantization, JPEG 2000 compression is lossy when a finite RMSE target is
+used. The analysis step reports the measured JPEG 2000 RMSE and the full
+round-trip RMSE in units of the estimated noise sigma.
+
+Relation to Noise Sigma
+~~~~~~~~~~~~~~~~~~~~~~~
+
+When ``--compress-center``, ``--compress-delta`` or ``--compress-j2k-rmse`` are
+not specified, ``tofu compress`` estimates them from the input data. It reads
+sample images, estimates the noise sigma for each image, and uses the median
+sigma as a robust noise estimate.
+
+The defaults are chosen so that compression error should stay small compared to
+the data noise:
+
+- ``--compress-center`` is estimated as the median grey value;
+- ``--compress-delta`` is optimized so that quantization RMSE is near the noise
+  target, with a lower bound of one quarter of the estimated sigma;
+- ``--compress-j2k-rmse`` defaults to one quarter of the estimated sigma.
+
+The analysis output prints quantities such as ``Data sigma / compress delta``,
+``RMSE / sigma of quantization``, ``RMSE / sigma of JPEG2000`` and
+``RMSE / sigma of all steps``. These values are intended to answer the practical
+question: is the compression error small compared to the noise already present
+in the data?
+
+Interactive Analysis Workflow
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A typical workflow is to analyze a representative subset first, inspect the
+automatically chosen parameters, and only then run the actual compression.
+
+First run analysis and visualization:
+
+.. code-block:: bash
+
+   tofu --verbose compress \
+       --images reco \
+       --output compressed-%04d.tif \
+       --compress-analyze \
+       --compress-visualize
+
+In analysis mode, no compressed output is written. Tofu estimates missing
+parameters and prints them to the log. Use ``--verbose`` to show the calculated
+values for ``--compress-center``, ``--compress-delta`` and
+``--compress-j2k-rmse``.
+
+With ``--compress-visualize``, two PyQtGraph windows are shown:
+
+- the companded image preview, with interactive black/white level controls and
+  mouse readout of pixel coordinate and intensity;
+- the tone-curve plot, showing all companders, the highlighted soft data range,
+  center, soft limits and hard limits.
+
+Use the image preview to judge whether the selected compander gives useful
+contrast. Use the tone-curve window to see how much of the data lies in the
+nearly linear region and how strongly the tails are compressed.
+
+Then run compression with the chosen parameters:
+
+.. code-block:: bash
+
+   tofu compress \
+       --images reco \
+       --output compressed-%04d.tif \
+       --compress-compander tanh \
+       --compress-center 0.0123 \
+       --compress-delta 0.0004 \
+       --compress-j2k-rmse 0.0004
+
+To decompress the data later, use the same center, delta and compander:
+
+.. code-block:: bash
+
+   tofu decompress \
+       --images compressed \
+       --output restored-%04d.tif \
+       --compress-compander tanh \
+       --compress-center 0.0123 \
+       --compress-delta 0.0004

--- a/docs/source/usage/postprocessing.rst
+++ b/docs/source/usage/postprocessing.rst
@@ -118,7 +118,7 @@ parameters from the already determined compression spacing:
 
 .. math::
 
-   h = \sigma = \sqrt{\frac{1}{2}}\,\Delta
+   h = \sigma = \Delta
 
 where :math:`\Delta` is ``--compress-delta``. In this mode Tofu disables
 ``--denoise-estimate-sigma`` before creating the UFO denoising task, so that

--- a/docs/source/usage/postprocessing.rst
+++ b/docs/source/usage/postprocessing.rst
@@ -96,6 +96,38 @@ maximum.
 The analysis step reports the measured JPEG 2000 RMSE and the full round-trip
 RMSE in units of the estimated noise sigma.
 
+Reconstruction Output
+~~~~~~~~~~~~~~~~~~~~~
+
+``tofu tomo`` and ``tofu reco`` can apply the same denoising and companding
+pipeline directly to reconstructed slices. Denoising is applied first, followed
+by companding and JPEG 2000 TIFF writing.
+
+Enable denoising with ``--denoise``. Enable companded output with
+``--compress-output``. Because reconstructed slices are only available while
+the pipeline is running, automatic compression parameter analysis is not
+possible in this mode. Specify ``--compress-center`` and ``--compress-delta``
+explicitly. If ``--compress-j2k-rmse`` is omitted, JPEG 2000 coding is
+lossless.
+
+For example::
+
+    tofu reco \
+        --projections projections.tif \
+        --output reconstruction.tif \
+        --denoise \
+        --denoise-h 0.002 \
+        --denoise-sigma 0.002 \
+        --compress-output \
+        --compress-center 0.01 \
+        --compress-delta 0.0001 \
+        --compress-bits 16
+
+``--denoise-compression-aware`` may be used together with
+``--compress-output`` to set the denoising ``h`` and ``sigma`` values from the
+compression delta. Both numbered output and the serialized single-file output
+of ``tofu reco`` support this processing.
+
 Denoising Before Compression
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/usage/postprocessing.rst
+++ b/docs/source/usage/postprocessing.rst
@@ -88,6 +88,11 @@ the already quantized companded image. This removes JPEG 2000 loss, but the
 overall compression can still be lossy because the tone-mapped data are
 quantized before encoding. Negative RMSE values are not valid.
 
+OpenJPEG uses all available CPU processors by default. Use
+``--output-jpeg2000-threads`` to limit the number of worker threads, for
+example ``--output-jpeg2000-threads 8``. A value of 0 keeps the default
+maximum.
+
 The analysis step reports the measured JPEG 2000 RMSE and the full round-trip
 RMSE in units of the estimated noise sigma.
 

--- a/docs/source/usage/postprocessing.rst
+++ b/docs/source/usage/postprocessing.rst
@@ -70,10 +70,10 @@ noise, so that compression does not become the dominant degradation.
 JPEG 2000 Compression
 ~~~~~~~~~~~~~~~~~~~~~
 
-The quantized companded image is then encoded with JPEG 2000. The option
-``--compress-j2k-rmse`` is specified in the original input grey-value units.
-Internally, Tofu converts it to the JPEG 2000 PSNR level using the physical
-range represented by the companded data:
+The quantized companded image is then encoded with JPEG 2000. For lossy
+JPEG 2000 output, the option ``--compress-j2k-rmse`` is specified in the
+original input grey-value units. Internally, Tofu converts it to the JPEG 2000
+PSNR level using the physical range represented by the companded data:
 
 .. math::
 
@@ -82,9 +82,40 @@ range represented by the companded data:
 where :math:`\Delta` is ``--compress-delta`` and :math:`D` is the quantized
 dynamic range.
 
-Like quantization, JPEG 2000 compression is lossy when a finite RMSE target is
-used. The analysis step reports the measured JPEG 2000 RMSE and the full
-round-trip RMSE in units of the estimated noise sigma.
+Like quantization, JPEG 2000 compression is lossy when a positive RMSE target
+is used. Set ``--compress-j2k-rmse 0`` to request lossless JPEG 2000 coding of
+the already quantized companded image. This removes JPEG 2000 loss, but the
+overall compression can still be lossy because the tone-mapped data are
+quantized before encoding. Negative RMSE values are not valid.
+
+The analysis step reports the measured JPEG 2000 RMSE and the full round-trip
+RMSE in units of the estimated noise sigma.
+
+Denoising Before Compression
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``tofu compress`` can run non-local means denoising before the companding step
+when ``--denoise`` is specified. The denoising options are shared with
+``tofu denoise``.
+
+The default denoising values follow the UFO filter constructor defaults:
+
+- ``--denoise-h 0`` estimates the smoothing parameter from the first image;
+- ``--denoise-sigma 0`` leaves explicit noise compensation disabled, unless
+  ``--denoise-estimate-sigma`` is also specified;
+- ``--denoise-estimate-sigma`` estimates ``sigma`` from the first image.
+
+For compression, ``--denoise-compression-aware`` sets both denoising scale
+parameters from the already determined compression spacing:
+
+.. math::
+
+   h = \sigma = \sqrt{\frac{1}{2}}\,\Delta
+
+where :math:`\Delta` is ``--compress-delta``. In this mode Tofu disables
+``--denoise-estimate-sigma`` before creating the UFO denoising task, so that
+``h`` and ``sigma`` stay matched to the compression parameters instead of being
+estimated independently by the filter.
 
 Relation to Noise Sigma
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -151,6 +182,34 @@ Then run compression with the chosen parameters:
        --compress-center 0.0123 \
        --compress-delta 0.0004 \
        --compress-j2k-rmse 0.0004
+
+To use lossless JPEG 2000 coding for the quantized companded image, set the
+JPEG 2000 RMSE target to zero:
+
+.. code-block:: bash
+
+   tofu compress \
+       --images reco \
+       --output compressed-%04d.tif \
+       --compress-compander tanh \
+       --compress-center 0.0123 \
+       --compress-delta 0.0004 \
+       --compress-j2k-rmse 0
+
+To denoise in a way that is tied to the compression spacing, add
+``--denoise`` and ``--denoise-compression-aware``:
+
+.. code-block:: bash
+
+   tofu compress \
+       --images reco \
+       --output compressed-%04d.tif \
+       --compress-compander tanh \
+       --compress-center 0.0123 \
+       --compress-delta 0.0004 \
+       --compress-j2k-rmse 0.0004 \
+       --denoise \
+       --denoise-compression-aware
 
 To decompress the data later, use the same center, delta and compander:
 

--- a/docs/source/usage/postprocessing.rst
+++ b/docs/source/usage/postprocessing.rst
@@ -14,6 +14,14 @@ This is useful when the data are floating point or have a wider useful dynamic
 range than the chosen output integer type. The compander keeps high precision
 near a chosen center value and spends less precision farther away from it.
 
+.. warning::
+
+   Be careful when compressing data arrays that contain metadata values, such
+   as timestamps, frame counters or other non-image measurements. These values
+   can affect the estimated compression parameters and may be quantized or
+   lossily encoded along with the image data. Store metadata separately, or
+   exclude it from the data passed to ``tofu compress``.
+
 Tone Mapping
 ~~~~~~~~~~~~
 

--- a/docs/source/usage/postprocessing.rst
+++ b/docs/source/usage/postprocessing.rst
@@ -118,7 +118,7 @@ First run analysis and visualization:
 
 .. code-block:: bash
 
-   tofu --verbose compress \
+   tofu compress --verbose \
        --images reco \
        --output compressed-%04d.tif \
        --compress-analyze \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,13 @@ authors = [
     { name = "Matthias Vogelgesang", email = "matthias.vogelgesang@kit.edu" },
 ]
 dependencies = [
+    "imagecodecs",
     "PyGObject",
     "PyQt5",
     "imageio",
     "numpy",
     "pyqtgraph",
+    "scipy",
     "tifffile",
     "scikit-image",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,10 @@ authors = [
 ]
 dependencies = [
     "PyGObject",
+    "PyQt5",
     "imageio",
     "numpy",
+    "pyqtgraph",
     "tifffile",
     "scikit-image",
 ]

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,13 @@ setup(
     scripts=['bin/tofu'],
     exclude_package_data={'': ['README.rst']},
     install_requires= [
+        'imagecodecs',
         'PyGObject',
         'PyQt5',
         'imageio',
         'numpy',
         'pyqtgraph',
+        'scipy',
         'tifffile',
         'scikit-image',
     ],

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,10 @@ setup(
     exclude_package_data={'': ['README.rst']},
     install_requires= [
         'PyGObject',
+        'PyQt5',
         'imageio',
         'numpy',
+        'pyqtgraph',
         'tifffile',
         'scikit-image',
     ],

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -92,10 +92,12 @@ class Compander(ABC):
         """Apply the inverse compander curve to scaled output values."""
 
     def quantize(self, image):
+        """Quantize *image* to the compander output dtype."""
         return np.rint(image).astype(get_uint_dtype(self.dynamic_range))
 
-    def create_ufo_task(self, direction='forward'):
-        task = get_task('compand')
+    def create_ufo_task(self, direction='forward', processing_node=None):
+        """Create a UFO compand task from this compander."""
+        task = get_task('compand', processing_node=processing_node)
         task.props.center = self.center
         task.props.delta = self.delta
         task.props.bits = int(np.log2(self.dynamic_range + 1))
@@ -284,6 +286,7 @@ def show_compander_tone_curves(args, softmin, softmax, hardmin, hardmax, num_poi
 
 
 def optimize_delta_to_sigma(args, sigma, images):
+    """Find a compression delta that keeps quantization RMSE near *sigma*."""
     dynamic_range = 2 ** args.compress_bits - 1
 
     def obj_func(delta):
@@ -314,6 +317,7 @@ def optimize_delta_to_sigma(args, sigma, images):
 
 
 def analyze(args, images):
+    """Log compression quality estimates for *images*."""
     LOG.debug("Compression info")
     sigma = np.median([get_sigma(image) for image in images])
     dynamic_range = 2 ** args.compress_bits - 1
@@ -392,31 +396,17 @@ def analyze(args, images):
         show_compander_tone_curves(args, softmin, softmax, hardmin, hardmax, show=True)
 
 
-def create_compression_pipeline(args, graph, direction='forward'):
-    """Create the UFO companding pipeline and return its last task."""
-    reader = get_task('read')
-    set_node_props(reader, args)
-    if not args.images:
-        raise RuntimeError('--images not set')
-    setup_read_task(reader, args.images, args)
-
-    dynamic_range = 2 ** args.compress_bits - 1
-    compander = TanhCompander(
-        args.compress_center,
-        args.compress_delta,
-        dynamic_range
-    ).create_ufo_task(direction=direction)
-
-    graph.connect_nodes(reader, compander)
-
-    return compander
-
-
-def compress(args):
+def determine_compression_parameters(args):
+    """Determine missing compression parameters from *args.images*."""
     images = None
     sigma = None
 
-    if not args.compress_delta or not args.compress_j2k_rmse or not args.compress_center or args.compress_analyze:
+    if (
+        not args.compress_delta
+        or not args.compress_j2k_rmse
+        or not args.compress_center
+        or getattr(args, 'compress_analyze', False)
+    ):
         images = read_image(args.images, args=args, allow_multi=True)
         args.compress_center = np.percentile(images, 50)
         LOG.debug("--compress-center calculated: %g", args.compress_center)
@@ -434,16 +424,45 @@ def compress(args):
 
     if sigma:
         LOG.debug("Noise sigma: %g", sigma)
+
+    args._compression_images = images
+
+
+def create_compression_pipeline(args, direction='forward', processing_node=None):
+    """Create and configure a UFO companding task."""
+    if direction == 'forward':
+        determine_compression_parameters(args)
+    elif args.compress_center is None or args.compress_delta is None:
+        raise RuntimeError('--compress-center and --compress-delta must be specified')
+
+    dynamic_range = 2 ** args.compress_bits - 1
+    return TanhCompander(
+        args.compress_center,
+        args.compress_delta,
+        dynamic_range
+    ).create_ufo_task(direction=direction, processing_node=processing_node)
+
+
+def compress(args):
+    """Run image compression using a UFO companding pipeline."""
+    compand = create_compression_pipeline(args)
+
     # Dynamic range rescaled to physical range
-    j2k_psnr = get_psnr(args.compress_delta * 2 ** args.compress_bits - 1, args.compress_j2k_rmse)
+    j2k_psnr = get_psnr(args.compress_delta * (2 ** args.compress_bits - 1), args.compress_j2k_rmse)
     LOG.info("JPEG2000 PSNR: %.2f", j2k_psnr)
 
     if args.compress_analyze:
-        analyze(args, images)
+        analyze(args, args._compression_images)
         return
 
     graph = Ufo.TaskGraph()
     sched = Ufo.Scheduler()
+
+    reader = get_task('read')
+    set_node_props(reader, args)
+    if not args.images:
+        raise RuntimeError('--images not set')
+    setup_read_task(reader, args.images, args)
 
     out_task = get_writer(args)
     if hasattr(out_task.props, 'bits'):
@@ -458,13 +477,14 @@ def compress(args):
             )
         ))
 
-    current = create_compression_pipeline(args, graph)
-    graph.connect_nodes(current, out_task)
+    graph.connect_nodes(reader, compand)
+    graph.connect_nodes(compand, out_task)
 
     run_scheduler(sched, graph)
 
 
 def decompress(args):
+    """Run image decompression using a UFO companding pipeline."""
     if args.compress_center is None:
         raise RuntimeError('--compress-center must be specified')
     if args.compress_delta is None:
@@ -473,8 +493,15 @@ def decompress(args):
     graph = Ufo.TaskGraph()
     sched = Ufo.Scheduler()
 
+    reader = get_task('read')
+    set_node_props(reader, args)
+    if not args.images:
+        raise RuntimeError('--images not set')
+    setup_read_task(reader, args.images, args)
+
     out_task = get_writer(args)
-    current = create_compression_pipeline(args, graph, direction='backward')
+    current = create_compression_pipeline(args, direction='backward')
+    graph.connect_nodes(reader, current)
     graph.connect_nodes(current, out_task)
 
     run_scheduler(sched, graph)

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -3,7 +3,9 @@ import logging
 import multiprocessing
 import numpy as np
 from abc import ABC, abstractmethod
-from tofu.util import read_image
+from gi.repository import Ufo
+from tofu.tasks import get_task, get_writer
+from tofu.util import read_image, run_scheduler, set_node_props, setup_read_task
 from tofu.metrics import get_sigma, get_psnr, get_rmse
 from scipy.optimize import minimize_scalar
 
@@ -93,12 +95,20 @@ class Compander(ABC):
         return np.rint(image).astype(get_uint_dtype(self.dynamic_range))
 
     def create_ufo_task(self):
-        from gi.repository import Ufo
-        pass
+        task = get_task('compand')
+        task.props.center = self.center
+        task.props.delta = self.delta
+        task.props.bits = int(np.log2(self.dynamic_range + 1))
+        task.props.direction = 'forward'
+        task.props.type = self.ufo_type
+
+        return task
 
 
 class TanhCompander(Compander):
     """Compress and expand values using a hyperbolic tangent curve."""
+
+    ufo_type = 'tanh'
 
     def forward(self, scaled):
         return np.tanh(scaled)
@@ -111,6 +121,8 @@ class TanhCompander(Compander):
 
 class ArctanCompander(Compander):
     """Compress and expand values using an arctangent curve."""
+
+    ufo_type = 'arctan'
 
     @property
     def scale_factor(self):
@@ -130,6 +142,8 @@ class ArctanCompander(Compander):
 class RecipSqRootCompander(Compander):
     """Compress and expand values using the x / sqrt(1 + x^2) function."""
 
+    ufo_type = 'recip_sqrt'
+
     def forward(self, scaled):
         return scaled / np.sqrt(1 + scaled ** 2)
 
@@ -142,6 +156,8 @@ class RecipSqRootCompander(Compander):
 
 class ClipCompander(Compander):
     """Compress and expand values using clipping."""
+
+    ufo_type = 'clip'
 
     def forward(self, scaled):
         return np.clip(scaled, -1, 1)
@@ -379,6 +395,26 @@ def analyze(args, images):
     LOG.debug("RMSE / sigma of all steps: %.2f", np.mean(rmse_full) / sigma)
 
 
+def create_compression_pipeline(args, graph):
+    """Create the UFO compression pipeline and return its last task."""
+    reader = get_task('read')
+    set_node_props(reader, args)
+    if not args.images:
+        raise RuntimeError('--images not set')
+    setup_read_task(reader, args.images, args)
+
+    dynamic_range = 2 ** args.compress_bits - 1
+    compander = TanhCompander(
+        args.compress_center,
+        args.compress_delta,
+        dynamic_range
+    ).create_ufo_task()
+
+    graph.connect_nodes(reader, compander)
+
+    return compander
+
+
 def compress(args):
     images = read_image(
         args.images, args=args, allow_multi=True
@@ -414,6 +450,27 @@ def compress(args):
     # show_compander_results(args, images[0], show=False)
     # hardmin, hardmax = np.percentile(images, (0, 100))
     # show_compander_tone_curves(args, hardmin, hardmax, show=True)
+
+    graph = Ufo.TaskGraph()
+    sched = Ufo.Scheduler()
+
+    out_task = get_writer(args)
+    if hasattr(out_task.props, 'bits'):
+        out_task.props.bits = args.compress_bits
+    if hasattr(out_task.props, 'tiff_jpeg2000'):
+        out_task.props.tiff_jpeg2000 = True
+    if hasattr(out_task.props, 'level'):
+        out_task.props.level = int(round(
+            get_psnr(
+                args.compress_delta * (2 ** args.compress_bits - 1),
+                args.compress_j2k_rmse
+            )
+        ))
+
+    current = create_compression_pipeline(args, graph)
+    graph.connect_nodes(current, out_task)
+
+    run_scheduler(sched, graph)
 
 
 def decompress(args):

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -94,12 +94,12 @@ class Compander(ABC):
     def quantize(self, image):
         return np.rint(image).astype(get_uint_dtype(self.dynamic_range))
 
-    def create_ufo_task(self):
+    def create_ufo_task(self, direction='forward'):
         task = get_task('compand')
         task.props.center = self.center
         task.props.delta = self.delta
         task.props.bits = int(np.log2(self.dynamic_range + 1))
-        task.props.direction = 'forward'
+        task.props.direction = direction
         task.props.type = self.ufo_type
 
         return task
@@ -395,8 +395,8 @@ def analyze(args, images):
     LOG.debug("RMSE / sigma of all steps: %.2f", np.mean(rmse_full) / sigma)
 
 
-def create_compression_pipeline(args, graph):
-    """Create the UFO compression pipeline and return its last task."""
+def create_compression_pipeline(args, graph, direction='forward'):
+    """Create the UFO companding pipeline and return its last task."""
     reader = get_task('read')
     set_node_props(reader, args)
     if not args.images:
@@ -408,7 +408,7 @@ def create_compression_pipeline(args, graph):
         args.compress_center,
         args.compress_delta,
         dynamic_range
-    ).create_ufo_task()
+    ).create_ufo_task(direction=direction)
 
     graph.connect_nodes(reader, compander)
 
@@ -474,4 +474,16 @@ def compress(args):
 
 
 def decompress(args):
-    pass
+    if args.compress_center is None:
+        raise RuntimeError('--compress-center must be specified')
+    if args.compress_delta is None:
+        raise RuntimeError('--compress-delta must be specified')
+
+    graph = Ufo.TaskGraph()
+    sched = Ufo.Scheduler()
+
+    out_task = get_writer(args)
+    current = create_compression_pipeline(args, graph, direction='backward')
+    graph.connect_nodes(current, out_task)
+
+    run_scheduler(sched, graph)

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -47,9 +47,13 @@ class Compander(ABC):
         """Get compander scale factor that maps input to quantized dynamic range."""
         return 2 / (self.delta * self.dynamic_range)
 
-    @abstractmethod
     def compress(self, image):
         """Compress the dynamic range of *image*."""
+        return self.quantize((1 + self.scale(image)) / 2 * self.dynamic_range)
+
+    @abstractmethod
+    def scale(self, image):
+        """Scale the dynamic range of *image* for the compressing function."""
 
     @abstractmethod
     def expand(self, image):
@@ -70,14 +74,8 @@ class TanhCompander(Compander):
         scaled = (value - self.center) * self.get_scale()
         return np.abs(scaled / 2 - np.tanh(scaled) / 2) * self.dynamic_range
 
-    def compress(self, image):
-        compressed = (
-            (1 + np.tanh((image - self.center) * self.get_scale()))
-            * self.dynamic_range
-            / 2
-        )
-
-        return self.quantize(compressed)
+    def scale(self, image):
+        return np.tanh((image - self.center) * self.get_scale())
 
     def expand(self, image):
         limit = np.nextafter(1.0, 0.0)
@@ -95,14 +93,8 @@ class ArctanCompander(Compander):
 
         return np.abs(deviation) * self.dynamic_range
 
-    def compress(self, image):
-        compressed = (
-            (1 + 2 / np.pi * np.arctan((image - self.center) * self.get_scale()))
-            * self.dynamic_range
-            / 2
-        )
-
-        return self.quantize(compressed)
+    def scale(self, image):
+        return 2 / np.pi * np.arctan((image - self.center) * self.get_scale())
 
     def expand(self, image):
         limit = np.nextafter(np.pi / 2, 0.0)
@@ -122,11 +114,9 @@ class RecipSqRootCompander(Compander):
         scaled = (value - self.center) * self.get_scale()
         return np.abs(scaled / 2 - scaled / np.sqrt(1 + scaled ** 2) / 2) * self.dynamic_range
 
-    def compress(self, image):
+    def scale(self, image):
         scaled = (image - self.center) * self.get_scale()
-        compressed = (1 + scaled / np.sqrt(1 + scaled ** 2)) * self.dynamic_range / 2
-
-        return self.quantize(compressed)
+        return scaled / np.sqrt(1 + scaled ** 2)
 
     def expand(self, image):
         limit = np.nextafter(1.0, 0.0)
@@ -142,11 +132,8 @@ class ClipCompander(Compander):
         scaled = (value - self.center) * self.get_scale()
         return np.abs(scaled / 2 - scaled / np.sqrt(1 + scaled ** 2) / 2) * self.dynamic_range
 
-    def compress(self, image):
-        scaled = np.clip((image - self.center) * self.get_scale(), -1, 1)
-        compressed = (1 + scaled) * self.dynamic_range / 2
-
-        return self.quantize(compressed)
+    def scale(self, image):
+        return np.clip((image - self.center) * self.get_scale(), -1, 1)
 
     def expand(self, image):
         limit = np.nextafter(1.0, 0.0)
@@ -220,12 +207,12 @@ def show_compander_tone_curves(args, num_points=1024, show=True):
     fig, ax = plt.subplots(figsize=(8, 6), constrained_layout=True)
 
     for name, compander in companders:
-        line, = ax.plot(values, compander.compress(values), alpha=0.25)
+        line, = ax.plot(values, compander.scale(values), alpha=0.25)
         color = line.get_color()
         if np.any(soft_mask):
             ax.plot(
                 values[soft_mask],
-                compander.compress(values[soft_mask]),
+                compander.scale(values[soft_mask]),
                 color=color,
                 label=name,
                 linewidth=2
@@ -400,7 +387,7 @@ def compress(args):
         args.compress_j2k_rmse = sigma / 4
 
     analyze(args, images)
-    show_compander_results(args, images[0], show=False)
+    # show_compander_results(args, images[0], show=False)
     show_compander_tone_curves(args, show=True)
 
 

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -48,6 +48,18 @@ class Compander(ABC):
         """Compander scale factor that maps input to quantized dynamic range."""
         return 2 / (self.delta * self.dynamic_range)
 
+    def normalize(self, image):
+        """Normalize input values around the compander center."""
+        return (image - self.center) * self.scale_factor
+
+    def denormalize(self, scaled):
+        """Denormalize scaled values back to input data units."""
+        return scaled / self.scale_factor + self.center
+
+    def scale(self, image):
+        """Scale the dynamic range of *image* for the compressing function."""
+        return self.forward(self.normalize(image))
+
     def compress(self, image, quantize=True):
         """Compress the dynamic range of *image*."""
         compressed = (1 + self.scale(image)) / 2 * self.dynamic_range
@@ -56,37 +68,41 @@ class Compander(ABC):
 
         return compressed
 
-    @abstractmethod
-    def scale(self, image):
-        """Scale the dynamic range of *image* for the compressing function."""
-
-    @abstractmethod
     def expand(self, image):
         """Expand a previously compressed *image*."""
+        scaled = 2 * image.astype(float) / self.dynamic_range - 1
+
+        return self.denormalize(self.inverse(scaled))
+
+    def get_linearity_deviation(self, value):
+        """Get deviation from linearity in output dynamic range."""
+        scaled = self.normalize(value)
+        deviation = scaled / 2 - self.forward(scaled) / 2
+
+        return np.abs(deviation) * self.dynamic_range
+
+    @abstractmethod
+    def forward(self, scaled):
+        """Apply the compander curve to normalized values."""
+
+    @abstractmethod
+    def inverse(self, scaled):
+        """Apply the inverse compander curve to scaled output values."""
 
     def quantize(self, image):
         return np.rint(image).astype(get_uint_dtype(self.dynamic_range))
-
-    @abstractmethod
-    def get_linearity_deviation(self, value):
-        """Get deviation from linearity in output dynamic range."""
 
 
 class TanhCompander(Compander):
     """Compress and expand values using a hyperbolic tangent curve."""
 
-    def get_linearity_deviation(self, value):
-        scaled = (value - self.center) * self.scale_factor
-        return np.abs(scaled / 2 - np.tanh(scaled) / 2) * self.dynamic_range
+    def forward(self, scaled):
+        return np.tanh(scaled)
 
-    def scale(self, image):
-        return np.tanh((image - self.center) * self.scale_factor)
-
-    def expand(self, image):
+    def inverse(self, scaled):
         limit = np.nextafter(1.0, 0.0)
-        scaled = np.clip(2 * image.astype(float) / self.dynamic_range - 1, -limit, limit)
 
-        return np.arctanh(scaled) / self.scale_factor + self.center
+        return np.arctanh(np.clip(scaled, -limit, limit))
 
 
 class ArctanCompander(Compander):
@@ -97,59 +113,39 @@ class ArctanCompander(Compander):
         """Get compander scale factor that maps input to quantized dynamic range."""
         return np.pi / (self.delta * self.dynamic_range)
 
-    def get_linearity_deviation(self, value):
-        scaled = (value - self.center) * self.scale_factor
-        deviation = scaled / 2 - 2 / np.pi * np.arctan(scaled) / 2
+    def forward(self, scaled):
+        return 2 / np.pi * np.arctan(scaled)
 
-        return np.abs(deviation) * self.dynamic_range
-
-    def scale(self, image):
-        return 2 / np.pi * np.arctan((image - self.center) * self.scale_factor)
-
-    def expand(self, image):
+    def inverse(self, scaled):
         limit = np.nextafter(np.pi / 2, 0.0)
-        scaled = np.clip(
-            (2 * image.astype(float) / self.dynamic_range - 1) * np.pi / 2,
-            -limit,
-            limit
-        )
+        scaled = np.clip(scaled * np.pi / 2, -limit, limit)
 
-        return np.tan(scaled) / self.scale_factor + self.center
+        return np.tan(scaled)
 
 
 class RecipSqRootCompander(Compander):
     """Compress and expand values using the x / sqrt(1 + x^2) function."""
 
-    def get_linearity_deviation(self, value):
-        scaled = (value - self.center) * self.scale_factor
-        return np.abs(scaled / 2 - scaled / np.sqrt(1 + scaled ** 2) / 2) * self.dynamic_range
-
-    def scale(self, image):
-        scaled = (image - self.center) * self.scale_factor
+    def forward(self, scaled):
         return scaled / np.sqrt(1 + scaled ** 2)
 
-    def expand(self, image):
+    def inverse(self, scaled):
         limit = np.nextafter(1.0, 0.0)
-        scaled = np.clip(2 * image.astype(float) / self.dynamic_range - 1, -limit, limit)
+        scaled = np.clip(scaled, -limit, limit)
 
-        return scaled / np.sqrt(1 - scaled ** 2) / self.scale_factor + self.center
+        return scaled / np.sqrt(1 - scaled ** 2)
 
 
 class ClipCompander(Compander):
-    """Compress and expand values using the x / sqrt(1 + x^2) function."""
+    """Compress and expand values using clipping."""
 
-    def get_linearity_deviation(self, value):
-        scaled = (value - self.center) * self.scale_factor
-        return np.abs(scaled / 2 - scaled / np.sqrt(1 + scaled ** 2) / 2) * self.dynamic_range
+    def forward(self, scaled):
+        return np.clip(scaled, -1, 1)
 
-    def scale(self, image):
-        return np.clip((image - self.center) * self.scale_factor, -1, 1)
-
-    def expand(self, image):
+    def inverse(self, scaled):
         limit = np.nextafter(1.0, 0.0)
-        scaled = np.clip(2 * image.astype(float) / self.dynamic_range - 1, -limit, limit)
 
-        return scaled / self.scale_factor + self.center
+        return np.clip(scaled, -limit, limit)
 
 
 def get_companders(args):

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -543,7 +543,8 @@ def analyze(args, images):
     )
     input_span = hardmax - hardmin
 
-    compander = TanhCompander(
+    compander_cls = COMPANDER_TYPES[getattr(args, 'compress_compander', 'tanh')]
+    compander = compander_cls(
         args.compress_center,
         args.compress_delta,
         dynamic_range
@@ -645,21 +646,21 @@ def determine_compression_parameters(args):
     sigma = None
 
     if (
-        not args.compress_delta
-        or not args.compress_j2k_rmse
-        or not args.compress_center
+        args.compress_delta is None
+        or args.compress_j2k_rmse is None
+        or args.compress_center is None
         or getattr(args, 'compress_analyze', False)
     ):
         images = read_image(args.images, args=args, allow_multi=True)
         args.compress_center = np.percentile(images, 50)
         LOG.debug("--compress-center calculated: %g", args.compress_center)
 
-    if not args.compress_delta:
+    if args.compress_delta is None:
         sigma = np.median([get_sigma(image) for image in images])
         # delta is max 1/4 of the noise sigma
         args.compress_delta = max(sigma / 4, optimize_delta_to_sigma(args, sigma, images))
         LOG.debug("--compress-delta calculated: %g", args.compress_delta)
-    if not args.compress_j2k_rmse:
+    if args.compress_j2k_rmse is None:
         sigma = np.median([get_sigma(image) for image in images])
         # j2k RMSE wrt original noise sigma is 1/4
         args.compress_j2k_rmse = sigma / 4

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -171,6 +171,14 @@ class ClipCompander(Compander):
         return np.clip(scaled, -limit, limit)
 
 
+COMPANDER_TYPES = {
+    "tanh": TanhCompander,
+    "arctan": ArctanCompander,
+    "recip_sqrt": RecipSqRootCompander,
+    "clip": ClipCompander,
+}
+
+
 def get_companders(args):
     """Return all available companders initialized from compression arguments."""
     dynamic_range = 2 ** args.compress_bits - 1
@@ -203,11 +211,14 @@ def show_compander_results(args, image, hardmin, hardmax, colormap="gray", show=
 
     for ax, (name, compander) in zip(axes, companders):
         compressed = compander.compress(image)
+        compressed_softmin, compressed_softmax = np.percentile(
+            compressed, (0.001, 100 - 0.001)
+        )
         color_image = ax.imshow(
             compressed,
             cmap=colormap,
-            vmin= (1 + compander.scale(hardmin)) / 2 * compander.dynamic_range,
-            vmax= (1 + compander.scale(hardmax)) / 2 * compander.dynamic_range
+            vmin=compressed_softmin,
+            vmax=compressed_softmax
         )
         ax.set_title(name)
         ax.axis("off")
@@ -351,6 +362,10 @@ def analyze(args, images):
         rmse_full.append(get_rmse(image, expanded_full))
 
     LOG.debug("Center: %g", args.compress_center)
+    LOG.debug("hardmin: %g", hardmin)
+    LOG.debug("hardmax: %g", hardmax)
+    LOG.debug("softmin: %g", softmin)
+    LOG.debug("softmax: %g", softmax)
     LOG.debug("Delta grey level: %g", args.compress_delta)
     LOG.debug("JPEG2000 RMSE: %g", args.compress_j2k_rmse)
     LOG.debug(
@@ -441,7 +456,9 @@ def create_compression_pipeline(args, direction='forward', processing_node=None)
     LOG.info("JPEG2000 PSNR: %.2f", j2k_psnr)
 
     dynamic_range = 2 ** args.compress_bits - 1
-    return TanhCompander(
+    compander_cls = COMPANDER_TYPES[getattr(args, 'compress_compander', 'tanh')]
+
+    return compander_cls(
         args.compress_center,
         args.compress_delta,
         dynamic_range

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -194,36 +194,62 @@ def get_companders(args):
     ]
 
 
-def show_compander_results(args, image, hardmin, hardmax, colormap="gray", show=True):
+def show_compander_results(args, image, hardmin=None, hardmax=None, colormap="gray", show=True):
     """Show compressed *image* results for every compander."""
     import matplotlib.pyplot as plt
+    from matplotlib.widgets import RangeSlider
 
     companders = get_companders(args)
+    compressed_images = [(name, compander.compress(image)) for name, compander in companders]
+    compressed_values = np.concatenate([compressed.ravel() for _, compressed in compressed_images])
+    compressed_min = np.min(compressed_values)
+    compressed_max = np.max(compressed_values)
+    compressed_softmin, compressed_softmax = np.percentile(compressed_values, (0.01, 99.99))
+    if compressed_min == compressed_max:
+        compressed_max = compressed_min + 1
+    if compressed_softmin == compressed_softmax:
+        compressed_softmax = compressed_max
+
     fig, axes = plt.subplots(
         2,
         2,
         figsize=(8, 8),
-        constrained_layout=True,
         squeeze=False
     )
+    fig.subplots_adjust(bottom=0.14, right=0.9)
     axes = axes.ravel()
-    color_image = None
+    color_images = []
 
-    for ax, (name, compander) in zip(axes, companders):
-        compressed = compander.compress(image)
-        compressed_softmin, compressed_softmax = np.percentile(
-            compressed, (0.001, 100 - 0.001)
-        )
+    for ax, (name, compressed) in zip(axes, compressed_images):
         color_image = ax.imshow(
             compressed,
             cmap=colormap,
             vmin=compressed_softmin,
             vmax=compressed_softmax
         )
+        color_images.append(color_image)
         ax.set_title(name)
         ax.axis("off")
 
-    fig.colorbar(color_image, ax=axes.tolist())
+    colorbar = fig.colorbar(color_images[-1], ax=axes.tolist())
+    slider_ax = fig.add_axes([0.18, 0.04, 0.64, 0.03])
+    slider = RangeSlider(
+        slider_ax,
+        "vmin/vmax",
+        compressed_min,
+        compressed_max,
+        valinit=(compressed_softmin, compressed_softmax)
+    )
+
+    def update_limits(limits):
+        vmin, vmax = limits
+        for color_image in color_images:
+            color_image.set_clim(vmin, vmax)
+        colorbar.update_normal(color_images[-1])
+        fig.canvas.draw_idle()
+
+    slider.on_changed(update_limits)
+    fig._tofu_vrange_slider = slider
 
     if show:
         plt.show()

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -183,7 +183,7 @@ def get_companders(args):
     ]
 
 
-def show_compander_results(args, image, colormap="gray", show=True):
+def show_compander_results(args, image, hardmin, hardmax, colormap="gray", show=True):
     """Show compressed *image* results for every compander."""
     import matplotlib.pyplot as plt
 
@@ -203,8 +203,8 @@ def show_compander_results(args, image, colormap="gray", show=True):
         color_image = ax.imshow(
             compressed,
             cmap=colormap,
-            vmin=0,
-            vmax=compander.dynamic_range
+            vmin= (1 + compander.scale(hardmin)) / 2 * compander.dynamic_range,
+            vmax= (1 + compander.scale(hardmax)) / 2 * compander.dynamic_range
         )
         ax.set_title(name)
         ax.axis("off")
@@ -217,14 +217,14 @@ def show_compander_results(args, image, colormap="gray", show=True):
     return fig
 
 
-def show_compander_tone_curves(args, hardmin, hardmax, num_points=1024, show=True):
+def show_compander_tone_curves(args, softmin, softmax, hardmin, hardmax, num_points=1024, show=True):
     """Show tone curves for every compander."""
     import matplotlib.pyplot as plt
 
     companders = get_companders(args)
 
     values = np.linspace(hardmin, hardmax, num=num_points)
-    soft_mask = (args.compress_softmin <= values) & (values <= args.compress_softmax)
+    soft_mask = (softmin <= values) & (values <= softmax)
     fig, ax = plt.subplots(figsize=(8, 6), constrained_layout=True)
 
     for name, compander in companders:
@@ -246,9 +246,14 @@ def show_compander_tone_curves(args, hardmin, hardmax, num_points=1024, show=Tru
         linewidth=1,
         label="center"
     )
-    ax.axvline(args.compress_softmin, color="0.4", linestyle=":", linewidth=1)
     ax.axvline(
-        args.compress_softmax,
+        softmin,
+        color="0.4",
+        linestyle=":",
+        linewidth=1
+    )
+    ax.axvline(
+        softmax,
         color="0.4",
         linestyle=":",
         linewidth=1,
@@ -311,9 +316,13 @@ def optimize_delta_to_sigma(args, sigma, images):
 def analyze(args, images):
     LOG.debug("Compression info")
     sigma = np.median([get_sigma(image) for image in images])
-    input_span = args.compress_softmax - args.compress_softmin
     dynamic_range = 2 ** args.compress_bits - 1
     delta_span = dynamic_range * args.compress_delta
+    hardmin, softmin, softmax, hardmax = np.percentile(
+        images,
+        (0, args.compress_input_percentile, 100 - args.compress_input_percentile, 100)
+    )
+    input_span = hardmax - hardmin
 
     compander = TanhCompander(
         args.compress_center,
@@ -325,7 +334,6 @@ def analyze(args, images):
     rmse_compander = []
     rmse_decoder = []
     rmse_full = []
-    import tifffile
     for image in images:
         compressed = compander.compress(image)
         encoded = imagecodecs.jpeg2k_encode(compressed, numthreads=CPU_COUNT, level=j2k_psnr)
@@ -335,26 +343,11 @@ def analyze(args, images):
 
         rmse_compander.append(get_rmse(image, expanded))
         rmse_decoder.append(get_rmse(expanded, expanded_full))
-        # rmse_decoder.append(get_rmse(compressed, decoded))
         rmse_full.append(get_rmse(image, expanded_full))
-        tifffile.imwrite("/mnt/fast3/compression/original.tif", image.astype(np.float32))
-        tifffile.imwrite("/mnt/fast3/compression/expanded.tif", expanded.astype(np.float32))
-        tifffile.imwrite(
-            "/mnt/fast3/compression/compressed-orig.tif",
-            expanded_full.astype(np.float32)
-        )
-        # tifffile.imwrite(
-        #     "/mnt/fast3/compression/compressed.tif",
-        #     compressed.astype(get_uint_dtype(dynamic_range)),
-        #     compression="jpeg2000",
-        #     compressionargs={"level": j2k_psnr}
-        # )
 
     LOG.debug("Center: %g", args.compress_center)
-    LOG.debug("Delta grey level: %g (native data range)", args.compress_delta)
-    LOG.debug("Noise sigma: %g (native data range)", sigma)
+    LOG.debug("Delta grey level: %g", args.compress_delta)
     LOG.debug("JPEG2000 RMSE: %g", args.compress_j2k_rmse)
-    LOG.debug("JPEG2000 PSNR: %.2f", j2k_psnr)
     LOG.debug(
         "Required dynamic range for given delta: %d",
         int(np.ceil(input_span / args.compress_delta)),
@@ -368,8 +361,8 @@ def analyze(args, images):
         delta_span / input_span
     )
     max_soft_deviation = max(
-        compander.get_linearity_deviation(args.compress_softmin),
-        compander.get_linearity_deviation(args.compress_softmax),
+        compander.get_linearity_deviation(softmin),
+        compander.get_linearity_deviation(softmax),
     )
     hardmin, hardmax = np.percentile(images, (0, 100))
     max_hard_deviation = max(
@@ -394,6 +387,10 @@ def analyze(args, images):
     )
     LOG.debug("RMSE / sigma of all steps: %.2f", np.mean(rmse_full) / sigma)
 
+    if args.compress_visualize:
+        show_compander_results(args, images[images.shape[0] // 2], hardmin, hardmax, show=False)
+        show_compander_tone_curves(args, softmin, softmax, hardmin, hardmax, show=True)
+
 
 def create_compression_pipeline(args, graph, direction='forward'):
     """Create the UFO companding pipeline and return its last task."""
@@ -416,40 +413,34 @@ def create_compression_pipeline(args, graph, direction='forward'):
 
 
 def compress(args):
-    images = read_image(
-        args.images, args=args, allow_multi=True
-    )
+    images = None
     sigma = None
-    if (
-        args.compress_softmin is None
-        or args.compress_softmax is None
-        or args.compress_center is None
-    ):
-        softmin, center, softmax = np.percentile(
-            images,
-            (args.compress_input_percentile, 50, 100 - args.compress_input_percentile)
-        )
-        if args.compress_center is None:
-            args.compress_center = center
-        if args.compress_softmin is None:
-            args.compress_softmin = softmin
-        if args.compress_softmax is None:
-            args.compress_softmax = softmax
+
+    if not args.compress_delta or not args.compress_j2k_rmse or not args.compress_center or args.compress_analyze:
+        images = read_image(args.images, args=args, allow_multi=True)
+        args.compress_center = np.percentile(images, 50)
+        LOG.debug("--compress-center calculated: %g", args.compress_center)
 
     if not args.compress_delta:
-        LOG.debug("delta / sigma not specified, optimizing...")
         sigma = np.median([get_sigma(image) for image in images])
         # delta is max 1/4 of the noise sigma
         args.compress_delta = max(sigma / 4, optimize_delta_to_sigma(args, sigma, images))
+        LOG.debug("--compress-delta calculated: %g", args.compress_delta)
     if not args.compress_j2k_rmse:
         sigma = np.median([get_sigma(image) for image in images])
         # j2k RMSE wrt original noise sigma is 1/4
         args.compress_j2k_rmse = sigma / 4
+        LOG.debug("--compress-j2k-rmse calculated using 1 / 4 of noise sigma: %g", args.compress_j2k_rmse)
 
-    analyze(args, images)
-    # show_compander_results(args, images[0], show=False)
-    # hardmin, hardmax = np.percentile(images, (0, 100))
-    # show_compander_tone_curves(args, hardmin, hardmax, show=True)
+    if sigma:
+        LOG.debug("Noise sigma: %g", sigma)
+    # Dynamic range rescaled to physical range
+    j2k_psnr = get_psnr(args.compress_delta * 2 ** args.compress_bits - 1, args.compress_j2k_rmse)
+    LOG.info("JPEG2000 PSNR: %.2f", j2k_psnr)
+
+    if args.compress_analyze:
+        analyze(args, images)
+        return
 
     graph = Ufo.TaskGraph()
     sched = Ufo.Scheduler()

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -195,60 +195,71 @@ def get_companders(args):
 
 
 def show_compander_results(args, image, hardmin=None, hardmax=None, colormap="gray", show=True):
-    """Show compressed *image* results for every compander."""
+    """Show compressed *image* result for the selected compander."""
     import matplotlib.pyplot as plt
     from matplotlib.widgets import RangeSlider
 
-    companders = get_companders(args)
-    compressed_images = [(name, compander.compress(image)) for name, compander in companders]
-    compressed_values = np.concatenate([compressed.ravel() for _, compressed in compressed_images])
-    compressed_min = np.min(compressed_values)
-    compressed_max = np.max(compressed_values)
-    compressed_softmin, compressed_softmax = np.percentile(compressed_values, (0.01, 99.99))
+    compander_name = getattr(args, 'compress_compander', 'tanh')
+    dynamic_range = 2 ** args.compress_bits - 1
+    compander = COMPANDER_TYPES[compander_name](
+        args.compress_center,
+        args.compress_delta,
+        dynamic_range
+    )
+    compressed = compander.compress(image)
+    compressed_min = np.min(compressed)
+    compressed_max = np.max(compressed)
+    compressed_softmin, compressed_softmax = np.percentile(compressed, (0.01, 99.99))
     if compressed_min == compressed_max:
         compressed_max = compressed_min + 1
     if compressed_softmin == compressed_softmax:
         compressed_softmax = compressed_max
 
-    fig, axes = plt.subplots(
-        2,
-        2,
-        figsize=(8, 8),
-        squeeze=False
+    fig = plt.figure(figsize=(9, 8))
+    image_rect = [0.01, 0.07, 0.9, 0.89]
+    fig_width, fig_height = fig.get_size_inches()
+    image_aspect = compressed.shape[1] / compressed.shape[0]
+    rect_aspect = image_rect[2] * fig_width / (image_rect[3] * fig_height)
+    if image_aspect > rect_aspect:
+        ax_width = image_rect[2]
+        ax_height = ax_width * fig_width / (image_aspect * fig_height)
+        ax_left = image_rect[0]
+        ax_bottom = image_rect[1] + (image_rect[3] - ax_height) / 2
+    else:
+        ax_height = image_rect[3]
+        ax_width = ax_height * fig_height * image_aspect / fig_width
+        ax_left = image_rect[0] + (image_rect[2] - ax_width) / 2
+        ax_bottom = image_rect[1]
+    ax = fig.add_axes([ax_left, ax_bottom, ax_width, ax_height])
+    colorbar_ax = fig.add_axes([0.93, 0.07, 0.015, 0.89])
+    color_image = ax.imshow(
+        compressed,
+        cmap=colormap,
+        vmin=compressed_softmin,
+        vmax=compressed_softmax
     )
-    fig.subplots_adjust(bottom=0.14, right=0.9)
-    axes = axes.ravel()
-    color_images = []
+    ax.set_title(compander_name, pad=2)
+    ax.axis("off")
 
-    for ax, (name, compressed) in zip(axes, compressed_images):
-        color_image = ax.imshow(
-            compressed,
-            cmap=colormap,
-            vmin=compressed_softmin,
-            vmax=compressed_softmax
-        )
-        color_images.append(color_image)
-        ax.set_title(name)
-        ax.axis("off")
-
-    colorbar = fig.colorbar(color_images[-1], ax=axes.tolist())
-    slider_ax = fig.add_axes([0.18, 0.04, 0.64, 0.03])
+    colorbar = fig.colorbar(color_image, cax=colorbar_ax)
+    slider_ax = fig.add_axes([0.18, 0.025, 0.64, 0.012])
     slider = RangeSlider(
         slider_ax,
         "vmin/vmax",
         compressed_min,
         compressed_max,
-        valinit=(compressed_softmin, compressed_softmax)
+        valinit=(compressed_softmin, compressed_softmax),
+        valfmt="%g"
     )
 
     def update_limits(limits):
         vmin, vmax = limits
-        for color_image in color_images:
-            color_image.set_clim(vmin, vmax)
-        colorbar.update_normal(color_images[-1])
+        color_image.set_clim(vmin, vmax)
+        colorbar.update_normal(color_image)
         fig.canvas.draw_idle()
 
     slider.on_changed(update_limits)
+    fig._tofu_colorbar = colorbar
     fig._tofu_vrange_slider = slider
 
     if show:

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -31,6 +31,10 @@ class Compander(ABC):
         self.delta = delta
         self.dynamic_range = dynamic_range
 
+    def get_scale(self):
+        """Get compander scale factor that maps input to quantized dynamic range."""
+        return 2 / (self.delta * self.dynamic_range)
+
     @abstractmethod
     def compress(self, image):
         """Compress the dynamic range of *image*."""
@@ -39,12 +43,8 @@ class Compander(ABC):
     def expand(self, image):
         """Expand a previously compressed *image*."""
 
-    @abstractmethod
-    def get_scale(self):
-        """Get compander scale factor that maps input to quantized dynamic range."""
-
     def quantize(self, image):
-        return image.astype(get_uint_dtype(self.dynamic_range))
+        return np.rint(image).astype(get_uint_dtype(self.dynamic_range))
 
     @abstractmethod
     def get_linearity_deviation(self, value):
@@ -57,9 +57,6 @@ class TanhCompander(Compander):
     def get_linearity_deviation(self, value):
         scaled = (value - self.center) * self.get_scale()
         return np.abs(scaled / 2 - np.tanh(scaled) / 2) * self.dynamic_range
-    
-    def get_scale(self):
-        return 2 / (self.delta * self.dynamic_range)
     
     def compress(self, image):
         compressed = (1 + np.tanh((image - self.center) * self.get_scale())) * self.dynamic_range / 2
@@ -80,9 +77,6 @@ class ArctanCompander(Compander):
         scaled = (value - self.center) * self.get_scale()
         return np.abs(scaled / 2 - 2 / np.pi * np.arctan(scaled) / 2) * self.dynamic_range
     
-    def get_scale(self):
-        return 2 / (self.delta * self.dynamic_range)
-    
     def compress(self, image):
         compressed = (1 + 2 / np.pi * np.arctan((image - self.center) * self.get_scale())) * self.dynamic_range / 2
 
@@ -99,12 +93,51 @@ class ArctanCompander(Compander):
         return np.tan(scaled) / self.get_scale() + self.center
 
 
+class RecipSqRootCompander(Compander):
+    """Compress and expand values using the x / sqrt(1 + x^2) function."""
+
+    def get_linearity_deviation(self, value):
+        scaled = (value - self.center) * self.get_scale()
+        return np.abs(scaled / 2 - scaled / np.sqrt(1 + scaled ** 2) / 2) * self.dynamic_range
+
+    def compress(self, image):
+        scaled = (image - self.center) * self.get_scale()
+        compressed = (1 + scaled / np.sqrt(1 + scaled ** 2)) * self.dynamic_range / 2
+
+        return self.quantize(compressed)
+
+    def expand(self, image):
+        limit = np.nextafter(1.0, 0.0)
+        scaled = np.clip(2 * image.astype(float) / self.dynamic_range - 1, -limit, limit)
+
+        return scaled / np.sqrt(1 - scaled ** 2) / self.get_scale() + self.center
+
+
+class ClipCompander(Compander):
+    """Compress and expand values using the x / sqrt(1 + x^2) function."""
+
+    def get_linearity_deviation(self, value):
+        scaled = (value - self.center) * self.get_scale()
+        return np.abs(scaled / 2 - scaled / np.sqrt(1 + scaled ** 2) / 2) * self.dynamic_range
+
+    def compress(self, image):
+        scaled = np.clip((image - self.center) * self.get_scale(), -1, 1)
+        compressed = (1 + scaled) * self.dynamic_range / 2
+
+        return self.quantize(compressed)
+
+    def expand(self, image):
+        limit = np.nextafter(1.0, 0.0)
+        scaled = np.clip(2 * image.astype(float) / self.dynamic_range - 1, -limit, limit)
+
+        return scaled / self.get_scale() + self.center
+
+
 def optimize_delta_to_sigma(args, sigma, images):
     dynamic_range = 2 ** args.compress_bits - 1
 
-    def obj_func(delta_to_sigma):
-        delta = delta_to_sigma * sigma
-        compander = TanhCompander(
+    def obj_func(delta):
+        compander = ClipCompander(
             args.compress_center,
             delta,
             dynamic_range
@@ -116,13 +149,16 @@ def optimize_delta_to_sigma(args, sigma, images):
             reco = compander.expand(compressed)
             rmses.append(get_rmse(image, reco))
             
-        return np.mean(rmses) / sigma
+        return np.mean(rmses)
     
     res = minimize_scalar(
-        obj_func, bounds=(0.05, 10), method="bounded", options={"xatol": 0.05}
+        obj_func,
+        bounds=(sigma / 20, 10 * sigma),
+        method="bounded",
+        options={"xatol": sigma / 20}
     )
-    LOG.debug("Optimized delta to sigma: %.2f", res.x)
-    LOG.debug("Optimized mean RMSE / sigma after quantization: %.2f", res.fun)
+    LOG.debug("Optimized delta / sigma: %.2f", res.x / sigma)
+    LOG.debug("Optimized RMSE / sigma after quantization: %.2f", res.fun / sigma)
     
     return res.x
 
@@ -134,12 +170,13 @@ def analyze(args, images):
     dynamic_range = 2 ** args.compress_bits - 1
     delta_span = dynamic_range * args.compress_delta
 
-    compander = TanhCompander(
+    compander = ClipCompander(
         args.compress_center,
         args.compress_delta,
         dynamic_range
     )
-    j2k_psnr = get_psnr(dynamic_range, args.compress_j2k_rmse)
+    # Dynamic range rescaled to physical range
+    j2k_psnr = get_psnr(args.compress_delta * dynamic_range, args.compress_j2k_rmse)
     rmse_compander = []
     rmse_decoder = []
     rmse_full = []
@@ -152,24 +189,30 @@ def analyze(args, images):
         expanded_full = compander.expand(decoded)
 
         rmse_compander.append(get_rmse(image, expanded))
-        # rmse_decoder.append(get_rmse(expanded, expanded_full))
-        rmse_decoder.append(get_rmse(compressed, decoded))
+        rmse_decoder.append(get_rmse(expanded, expanded_full))
+        # rmse_decoder.append(get_rmse(compressed, decoded))
         rmse_full.append(get_rmse(image, expanded_full))
         tifffile.imwrite("/mnt/fast3/compression/original.tif", image.astype(np.float32))
         tifffile.imwrite("/mnt/fast3/compression/expanded.tif", expanded.astype(np.float32))
-        tifffile.imwrite("/mnt/fast3/compression/compressed.tif", expanded_full.astype(np.float32))
+        tifffile.imwrite("/mnt/fast3/compression/compressed-orig.tif", expanded_full.astype(np.float32))
+        # tifffile.imwrite(
+        #     "/mnt/fast3/compression/compressed.tif",
+        #     compressed.astype(get_uint_dtype(dynamic_range)),
+        #     compression="jpeg2000",
+        #     compressionargs={"level": j2k_psnr}
+        # )
 
     LOG.debug("Center: %g", args.compress_center)
     LOG.debug("Delta grey level: %g (native data range)", args.compress_delta)
     LOG.debug("Noise sigma: %g (native data range)", sigma)
-    LOG.debug("Quantized noise sigma: %g (grey levels)", sigma / args.compress_delta)
+    LOG.debug("JPEG2000 RMSE: %g", args.compress_j2k_rmse)
     LOG.debug("JPEG2000 PSNR: %.2f", j2k_psnr)
     LOG.debug(
         "Required dynamic range for given delta: %d",
         int(np.ceil(input_span / args.compress_delta)),
     )
     LOG.debug("Data sigma / compress delta: %.2f (should be > 1)", sigma / args.compress_delta)
-    LOG.debug("Quantized span / soft data span: %.2f (should be > 1)", delta_span / input_span)
+    LOG.debug("Dynamic range / soft data dynamic range: %.2f (should be > 1)", delta_span / input_span)
     max_soft_deviation = max(
         compander.get_linearity_deviation(args.compress_softmin),
         compander.get_linearity_deviation(args.compress_softmax),
@@ -189,9 +232,13 @@ def analyze(args, images):
         max_hard_deviation,
         max_hard_deviation / dynamic_range * 100
     )
-    LOG.debug("Mean RMSE / sigma after quantization: %.2f", np.mean(rmse_compander) / sigma)
-    LOG.debug("JPEG2000 RMSE: %.2f / %.2f (target/measured)", args.compress_j2k_rmse, np.mean(rmse_decoder))
-    LOG.debug("Final mean RMSE / sigma after all steps: %.2f", np.mean(rmse_full) / sigma)
+    LOG.debug("RMSE / sigma of quantization: %.2f", np.mean(rmse_compander) / sigma)
+    LOG.debug(
+        "RMSE / sigma of JPEG2000: %.2f / %.2f (measured / target)",
+        np.mean(rmse_decoder) / sigma,
+        args.compress_j2k_rmse / sigma
+    )
+    LOG.debug("RMSE / sigma of all steps: %.2f", np.mean(rmse_full) / sigma)
 
 
 def compress(args):
@@ -224,12 +271,11 @@ def compress(args):
         LOG.debug("delta / sigma not specified, optimizing...")
         sigma = np.median([get_sigma(image) for image in images])
         # delta is max 1/4 of the noise sigma
-        args.compress_delta = max(0.25, optimize_delta_to_sigma(args, sigma, images)) * sigma
-        
+        args.compress_delta = max(sigma / 4, optimize_delta_to_sigma(args, sigma, images))
     if not args.compress_j2k_rmse:
         sigma = np.median([get_sigma(image) for image in images])
-        # j2k compression error max 1/2 of the quantized noise sigma
-        args.compress_j2k_rmse = sigma / args.compress_delta / 2
+        # j2k RMSE wrt original noise sigma is 1/4
+        args.compress_j2k_rmse = sigma / 4
 
     analyze(args, images)
     

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -4,6 +4,7 @@ import multiprocessing
 import numpy as np
 from abc import ABC, abstractmethod
 from gi.repository import Ufo
+from tofu.denoise import create_denoising_pipeline
 from tofu.tasks import get_task, get_writer
 from tofu.util import read_image, run_scheduler, set_node_props, setup_read_task
 from tofu.metrics import get_sigma, get_psnr, get_rmse
@@ -435,6 +436,10 @@ def create_compression_pipeline(args, direction='forward', processing_node=None)
     elif args.compress_center is None or args.compress_delta is None:
         raise RuntimeError('--compress-center and --compress-delta must be specified')
 
+    # Dynamic range rescaled to physical range
+    j2k_psnr = get_psnr(args.compress_delta * (2 ** args.compress_bits - 1), args.compress_j2k_rmse)
+    LOG.info("JPEG2000 PSNR: %.2f", j2k_psnr)
+
     dynamic_range = 2 ** args.compress_bits - 1
     return TanhCompander(
         args.compress_center,
@@ -446,10 +451,6 @@ def create_compression_pipeline(args, direction='forward', processing_node=None)
 def compress(args):
     """Run image compression using a UFO companding pipeline."""
     compand = create_compression_pipeline(args)
-
-    # Dynamic range rescaled to physical range
-    j2k_psnr = get_psnr(args.compress_delta * (2 ** args.compress_bits - 1), args.compress_j2k_rmse)
-    LOG.info("JPEG2000 PSNR: %.2f", j2k_psnr)
 
     if args.compress_analyze:
         analyze(args, args._compression_images)
@@ -477,7 +478,13 @@ def compress(args):
             )
         ))
 
-    graph.connect_nodes(reader, compand)
+    current = reader
+    if getattr(args, 'denoise', False):
+        denoise = create_denoising_pipeline(args)
+        graph.connect_nodes(current, denoise)
+        current = denoise
+
+    graph.connect_nodes(current, compand)
     graph.connect_nodes(compand, out_task)
 
     run_scheduler(sched, graph)

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -92,6 +92,10 @@ class Compander(ABC):
     def quantize(self, image):
         return np.rint(image).astype(get_uint_dtype(self.dynamic_range))
 
+    def create_ufo_task(self):
+        from gi.repository import Ufo
+        pass
+
 
 class TanhCompander(Compander):
     """Compress and expand values using a hyperbolic tangent curve."""
@@ -262,7 +266,7 @@ def optimize_delta_to_sigma(args, sigma, images):
     dynamic_range = 2 ** args.compress_bits - 1
 
     def obj_func(delta):
-        compander = ClipCompander(
+        compander = TanhCompander(
             args.compress_center,
             delta,
             dynamic_range
@@ -295,7 +299,7 @@ def analyze(args, images):
     dynamic_range = 2 ** args.compress_bits - 1
     delta_span = dynamic_range * args.compress_delta
 
-    compander = ClipCompander(
+    compander = TanhCompander(
         args.compress_center,
         args.compress_delta,
         dynamic_range
@@ -377,16 +381,9 @@ def analyze(args, images):
 
 def compress(args):
     images = read_image(
-        args.images, image_start=args.image_start, image_step=args.image_step, allow_multi=True
+        args.images, args=args, allow_multi=True
     )
     sigma = None
-    side = np.minimum(images.shape[-1], images.shape[-2])
-    inner_side = int(side / np.sqrt(2))
-    images = images[
-        :,
-        (images.shape[1] - inner_side) // 2:-(images.shape[1] - inner_side) // 2,
-        (images.shape[2] - inner_side) // 2:-(images.shape[2] - inner_side) // 2
-    ]
     if (
         args.compress_softmin is None
         or args.compress_softmax is None
@@ -415,8 +412,8 @@ def compress(args):
 
     analyze(args, images)
     # show_compander_results(args, images[0], show=False)
-    hardmin, hardmax = np.percentile(images, (0, 100))
-    show_compander_tone_curves(args, hardmin, hardmax, show=True)
+    # hardmin, hardmax = np.percentile(images, (0, 100))
+    # show_compander_tone_curves(args, hardmin, hardmax, show=True)
 
 
 def decompress(args):

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -670,6 +670,14 @@ def determine_compression_parameters(args):
     """Determine missing compression parameters from *args.images*."""
     images = None
     sigma = None
+    denoise_needs_parameters = (
+        getattr(args, 'denoise', False) and
+        not getattr(args, 'denoise_compression_aware', False) and
+        (
+            getattr(args, 'denoise_h', 0.0) <= 0.0 or
+            getattr(args, 'denoise_sigma', 0.0) <= 0.0
+        )
+    )
 
     if (
         args.compress_delta is None
@@ -678,8 +686,9 @@ def determine_compression_parameters(args):
         or getattr(args, 'compress_analyze', False)
     ):
         images = read_image(args.images, args=args, allow_multi=True)
-        args.compress_center = np.percentile(images, 50)
-        LOG.debug("--compress-center calculated: %g", args.compress_center)
+        if args.compress_center is None:
+            args.compress_center = np.percentile(images, 50)
+            LOG.debug("--compress-center calculated: %g", args.compress_center)
 
     if args.compress_delta is None:
         sigma = np.median([get_sigma(image) for image in images])
@@ -692,6 +701,15 @@ def determine_compression_parameters(args):
         # j2k RMSE wrt original noise sigma is 1/4
         args.compress_j2k_rmse = sigma / 4
         LOG.debug("--compress-j2k-rmse calculated using 1 / 4 of noise sigma: %g", args.compress_j2k_rmse)
+    if denoise_needs_parameters:
+        denoise_value = sigma if sigma is not None else args.compress_delta
+        denoise_source = "noise sigma" if sigma is not None else "compression delta"
+        if args.denoise_h <= 0.0:
+            args.denoise_h = denoise_value
+            LOG.debug("--denoise-h calculated using %s: %g", denoise_source, args.denoise_h)
+        if args.denoise_sigma <= 0.0:
+            args.denoise_sigma = denoise_value
+            LOG.debug("--denoise-sigma calculated using %s: %g", denoise_source, args.denoise_sigma)
 
     if sigma:
         LOG.debug("Noise sigma: %g", sigma)

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -1,11 +1,14 @@
-from abc import ABC, abstractmethod
+import imagecodecs
 import logging
-
+import multiprocessing
 import numpy as np
+from abc import ABC, abstractmethod
 from tofu.util import read_image
 from tofu.metrics import get_sigma, get_psnr, get_rmse
+from scipy.optimize import minimize_scalar
 
 LOG = logging.getLogger(__name__)
+CPU_COUNT = multiprocessing.cpu_count()
 
 __all__ = ["ArctanCompander", "Compander", "TanhCompander", "compress", "decompress"]
 
@@ -23,11 +26,9 @@ def get_uint_dtype(dynamic_range):
 class Compander(ABC):
     """Base class for reversible dynamic range companders."""
 
-    def __init__(self, center, input_span, quantized_span, output_percentile, dynamic_range):
+    def __init__(self, center, delta, dynamic_range):
         self.center = center
-        self.input_span = input_span
-        self.quantized_span = quantized_span
-        self.output_percentile = output_percentile
+        self.delta = delta
         self.dynamic_range = dynamic_range
 
     @abstractmethod
@@ -42,15 +43,28 @@ class Compander(ABC):
     def get_scale(self):
         """Get compander scale factor that maps input to quantized dynamic range."""
 
+    def quantize(self, image):
+        return image.astype(get_uint_dtype(self.dynamic_range))
+
+    @abstractmethod
+    def get_linearity_deviation(self, value):
+        """Get deviation from linearity based on the compressing function in output dynamic range."""    
+
 
 class TanhCompander(Compander):
     """Compress and expand values using a hyperbolic tangent curve."""
 
+    def get_linearity_deviation(self, value):
+        scaled = (value - self.center) * self.get_scale()
+        return np.abs(scaled / 2 - np.tanh(scaled) / 2) * self.dynamic_range
+    
     def get_scale(self):
-        return 2 * np.arctanh(self.output_percentile) / self.quantized_span
+        return 2 / (self.delta * self.dynamic_range)
     
     def compress(self, image):
-        return 0.5 * (1 + np.tanh((image - self.center) * self.get_scale())) * self.dynamic_range
+        compressed = (1 + np.tanh((image - self.center) * self.get_scale())) * self.dynamic_range / 2
+
+        return self.quantize(compressed)
 
     def expand(self, image):
         limit = np.nextafter(1.0, 0.0)
@@ -62,41 +76,122 @@ class TanhCompander(Compander):
 class ArctanCompander(Compander):
     """Compress and expand values using an arctangent curve."""
 
+    def get_linearity_deviation(self, value):
+        scaled = (value - self.center) * self.get_scale()
+        return np.abs(scaled / 2 - 2 / np.pi * np.arctan(scaled) / 2) * self.dynamic_range
+    
+    def get_scale(self):
+        return 2 / (self.delta * self.dynamic_range)
+    
     def compress(self, image):
-        normalized = self._normalize(image)
-        compressed = np.arctan(self.strength * normalized) / np.arctan(self.strength)
+        compressed = (1 + 2 / np.pi * np.arctan((image - self.center) * self.get_scale())) * self.dynamic_range / 2
 
-        return self._denormalize(compressed)
+        return self.quantize(compressed)
 
     def expand(self, image):
-        normalized = self._normalize(image)
-        expanded = np.tan(normalized * np.arctan(self.strength)) / self.strength
+        limit = np.nextafter(np.pi / 2, 0.0)
+        scaled = np.clip(
+            (2 * image.astype(float) / self.dynamic_range - 1) * np.pi / 2,
+            -limit,
+            limit
+        )
 
-        return self._denormalize(expanded)
+        return np.tan(scaled) / self.get_scale() + self.center
 
 
-def analyze(args, minimum, maximum):
-    input_span = maximum - minimum
+def optimize_delta_to_sigma(args, sigma, images):
+    dynamic_range = 2 ** args.compress_bits - 1
+
+    def obj_func(delta_to_sigma):
+        delta = delta_to_sigma * sigma
+        compander = TanhCompander(
+            args.compress_center,
+            delta,
+            dynamic_range
+        )
+
+        rmses = []
+        for image in images:
+            compressed = compander.compress(image).astype(get_uint_dtype(dynamic_range))
+            reco = compander.expand(compressed)
+            rmses.append(get_rmse(image, reco))
+            
+        return np.mean(rmses) / sigma
+    
+    res = minimize_scalar(
+        obj_func, bounds=(0.05, 10), method="bounded", options={"xatol": 0.05}
+    )
+    LOG.debug("Optimized delta to sigma: %.2f", res.x)
+    LOG.debug("Optimized mean RMSE / sigma after quantization: %.2f", res.fun)
+    
+    return res.x
+
+
+def analyze(args, images):
+    LOG.debug("Compression info")
+    sigma = np.median([get_sigma(image) for image in images])
+    input_span = args.compress_softmax - args.compress_softmin
     dynamic_range = 2 ** args.compress_bits - 1
     delta_span = dynamic_range * args.compress_delta
 
-    LOG.debug("Compression info")
+    compander = TanhCompander(
+        args.compress_center,
+        args.compress_delta,
+        dynamic_range
+    )
+    j2k_psnr = get_psnr(dynamic_range, args.compress_j2k_rmse)
+    rmse_compander = []
+    rmse_decoder = []
+    rmse_full = []
+    import tifffile
+    for image in images:
+        compressed = compander.compress(image)
+        encoded = imagecodecs.jpeg2k_encode(compressed, numthreads=CPU_COUNT, level=j2k_psnr)
+        decoded = imagecodecs.jpeg2k_decode(encoded, numthreads=CPU_COUNT)
+        expanded = compander.expand(compressed)
+        expanded_full = compander.expand(decoded)
+
+        rmse_compander.append(get_rmse(image, expanded))
+        # rmse_decoder.append(get_rmse(expanded, expanded_full))
+        rmse_decoder.append(get_rmse(compressed, decoded))
+        rmse_full.append(get_rmse(image, expanded_full))
+        tifffile.imwrite("/mnt/fast3/compression/original.tif", image.astype(np.float32))
+        tifffile.imwrite("/mnt/fast3/compression/expanded.tif", expanded.astype(np.float32))
+        tifffile.imwrite("/mnt/fast3/compression/compressed.tif", expanded_full.astype(np.float32))
+
     LOG.debug("Center: %g", args.compress_center)
-    LOG.debug("Noise sigma: %g", args.compress_sigma)
-    LOG.debug("Compress delta: %g", args.compress_delta)
+    LOG.debug("Delta grey level: %g (native data range)", args.compress_delta)
+    LOG.debug("Noise sigma: %g (native data range)", sigma)
+    LOG.debug("Quantized noise sigma: %g (grey levels)", sigma / args.compress_delta)
+    LOG.debug("JPEG2000 PSNR: %.2f", j2k_psnr)
     LOG.debug(
         "Required dynamic range for given delta: %d",
         int(np.ceil(input_span / args.compress_delta)),
     )
-    LOG.debug("Data span for percentile %g: %g", args.compress_input_percentile, input_span)
-    LOG.debug(
-        "Possible span for dynamic range %d and compress delta %g: %g",
-        dynamic_range,
-        args.compress_delta,
-        delta_span
+    LOG.debug("Data sigma / compress delta: %.2f (should be > 1)", sigma / args.compress_delta)
+    LOG.debug("Quantized span / soft data span: %.2f (should be > 1)", delta_span / input_span)
+    max_soft_deviation = max(
+        compander.get_linearity_deviation(args.compress_softmin),
+        compander.get_linearity_deviation(args.compress_softmax),
     )
-    LOG.debug("Data sigma / compress delta: %.2f (should be > 1)", args.compress_sigma / args.compress_delta)
-    LOG.debug("Possible span / data span: %.2f (should be > 1)", delta_span / input_span)
+    hardmin, hardmax = np.percentile(images, (0, 100))
+    max_hard_deviation = max(
+        compander.get_linearity_deviation(hardmin),
+        compander.get_linearity_deviation(hardmax),
+    )
+    LOG.debug(
+        "Max linearity deviation within soft limits: %.2f (%.3f %% of output dynamic range)",
+        max_soft_deviation,
+        max_soft_deviation / dynamic_range * 100
+    )
+    LOG.debug(
+        "Max linearity deviation within image range: %.2f (%.3f %% of output dynamic range)",
+        max_hard_deviation,
+        max_hard_deviation / dynamic_range * 100
+    )
+    LOG.debug("Mean RMSE / sigma after quantization: %.2f", np.mean(rmse_compander) / sigma)
+    LOG.debug("JPEG2000 RMSE: %.2f / %.2f (target/measured)", args.compress_j2k_rmse, np.mean(rmse_decoder))
+    LOG.debug("Final mean RMSE / sigma after all steps: %.2f", np.mean(rmse_full) / sigma)
 
 
 def compress(args):
@@ -104,6 +199,7 @@ def compress(args):
     images = read_image(
         args.images, image_start=args.image_start, image_step=args.image_step, allow_multi=True
     )
+    sigma = None
     side = np.minimum(images.shape[-1], images.shape[-2])
     inner_side = int(side / np.sqrt(2))
     margin = side - inner_side
@@ -112,43 +208,31 @@ def compress(args):
         (images.shape[1] - inner_side) // 2:-(images.shape[1] - inner_side) // 2,
         (images.shape[2] - inner_side) // 2:-(images.shape[2] - inner_side) // 2
     ]
-    minimum, center, maximum = np.percentile(
-        images,
-        (args.compress_input_percentile, 50, 100 - args.compress_input_percentile)
-    )
-    if not args.compress_sigma:
-        args.compress_sigma = np.median([get_sigma(image) for image in images])
-
-    if args.compress_center is None:
-        args.compress_center = center
+    if args.compress_softmin is None or args.compress_softmax is None or args.compress_center is None:
+        softmin, center, softmax = np.percentile(
+            images,
+            (args.compress_input_percentile, 50, 100 - args.compress_input_percentile)
+        )
+        if args.compress_center is None:
+            args.compress_center = center
+        if args.compress_softmin is None:
+            args.compress_softmin = softmin
+        if args.compress_softmax is None:
+            args.compress_softmax = softmax
 
     if not args.compress_delta:
-        args.compress_delta = args.compress_sigma / 4
+        LOG.debug("delta / sigma not specified, optimizing...")
+        sigma = np.median([get_sigma(image) for image in images])
+        # delta is max 1/4 of the noise sigma
+        args.compress_delta = max(0.25, optimize_delta_to_sigma(args, sigma, images)) * sigma
+        
+    if not args.compress_j2k_rmse:
+        sigma = np.median([get_sigma(image) for image in images])
+        # j2k compression error max 1/2 of the quantized noise sigma
+        args.compress_j2k_rmse = sigma / args.compress_delta / 2
 
-    analyze(args, minimum, maximum)
-
-    compander = TanhCompander(
-        args.compress_center,
-        maximum - minimum,
-        args.compress_delta * dynamic_range,
-        args.compress_output_percentile / 100,
-        dynamic_range
-    )
-    im = images[0]
-    #compressed = compander.compress(im)
-    #expanded = compander.expand(compressed)
-    #print(get_rmse(im, expanded) / args.compress_sigma)
-    linear_range = np.arange(dynamic_range + 1)
-    input_range = (linear_range - (dynamic_range + 1) / 2.0) * args.compress_delta
-    compressed_range = compander.compress(input_range)
-
-    print(np.tanh(args.compress_delta * dynamic_range * compander.get_scale() / 2))
-    print(compander.compress(args.compress_delta * dynamic_range / 2))
-    print(compander.compress(input_range))
-    import matplotlib.pyplot as plt
-    plt.plot(compressed_range)
-    plt.show()
-
+    analyze(args, images)
+    
 
 def decompress(args):
     pass

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -40,6 +40,16 @@ def get_uint_dtype(dynamic_range):
     raise ValueError("data range does not fit into uint16")
 
 
+def get_jpeg2000_level(data_range, rmse):
+    """Return a JPEG 2000 level from a target RMSE."""
+    if rmse < 0:
+        raise ValueError("--compress-j2k-rmse must be non-negative")
+    if rmse == 0:
+        return 0
+
+    return get_psnr(data_range, rmse)
+
+
 def run_qt_app(app):
     """Run a Qt application across PyQt versions."""
     if hasattr(app, 'exec'):
@@ -566,7 +576,7 @@ def analyze(args, images):
         dynamic_range
     )
     # Dynamic range rescaled to physical range
-    j2k_psnr = get_psnr(args.compress_delta * dynamic_range, args.compress_j2k_rmse)
+    j2k_psnr = get_jpeg2000_level(args.compress_delta * dynamic_range, args.compress_j2k_rmse)
     rmse_compander = []
     rmse_decoder = []
     rmse_full = []
@@ -696,8 +706,14 @@ def create_compression_pipeline(args, direction='forward', processing_node=None)
         raise RuntimeError('--compress-center and --compress-delta must be specified')
 
     # Dynamic range rescaled to physical range
-    j2k_psnr = get_psnr(args.compress_delta * (2 ** args.compress_bits - 1), args.compress_j2k_rmse)
-    LOG.info("JPEG2000 PSNR: %.2f", j2k_psnr)
+    j2k_psnr = get_jpeg2000_level(
+        args.compress_delta * (2 ** args.compress_bits - 1),
+        args.compress_j2k_rmse
+    )
+    if j2k_psnr == 0:
+        LOG.info("JPEG2000: lossless")
+    else:
+        LOG.info("JPEG2000 PSNR: %.2f", j2k_psnr)
 
     dynamic_range = 2 ** args.compress_bits - 1
     compander_cls = COMPANDER_TYPES[getattr(args, 'compress_compander', 'tanh')]
@@ -733,7 +749,7 @@ def compress(args):
         out_task.props.tiff_jpeg2000 = True
     if hasattr(out_task.props, 'level'):
         out_task.props.level = int(round(
-            get_psnr(
+            get_jpeg2000_level(
                 args.compress_delta * (2 ** args.compress_bits - 1),
                 args.compress_j2k_rmse
             )

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -10,7 +10,19 @@ from scipy.optimize import minimize_scalar
 LOG = logging.getLogger(__name__)
 CPU_COUNT = multiprocessing.cpu_count()
 
-__all__ = ["ArctanCompander", "Compander", "TanhCompander", "compress", "decompress"]
+__all__ = [
+    "ArctanCompander",
+    "ClipCompander",
+    "Compander",
+    "RecipSqRootCompander",
+    "TanhCompander",
+    "compress",
+    "decompress",
+    "get_companders",
+    "get_uint_dtype",
+    "show_compander_results",
+    "show_compander_tone_curves",
+]
 
 
 def get_uint_dtype(dynamic_range):
@@ -48,7 +60,7 @@ class Compander(ABC):
 
     @abstractmethod
     def get_linearity_deviation(self, value):
-        """Get deviation from linearity based on the compressing function in output dynamic range."""    
+        """Get deviation from linearity in output dynamic range."""
 
 
 class TanhCompander(Compander):
@@ -57,9 +69,13 @@ class TanhCompander(Compander):
     def get_linearity_deviation(self, value):
         scaled = (value - self.center) * self.get_scale()
         return np.abs(scaled / 2 - np.tanh(scaled) / 2) * self.dynamic_range
-    
+
     def compress(self, image):
-        compressed = (1 + np.tanh((image - self.center) * self.get_scale())) * self.dynamic_range / 2
+        compressed = (
+            (1 + np.tanh((image - self.center) * self.get_scale()))
+            * self.dynamic_range
+            / 2
+        )
 
         return self.quantize(compressed)
 
@@ -75,10 +91,16 @@ class ArctanCompander(Compander):
 
     def get_linearity_deviation(self, value):
         scaled = (value - self.center) * self.get_scale()
-        return np.abs(scaled / 2 - 2 / np.pi * np.arctan(scaled) / 2) * self.dynamic_range
-    
+        deviation = scaled / 2 - 2 / np.pi * np.arctan(scaled) / 2
+
+        return np.abs(deviation) * self.dynamic_range
+
     def compress(self, image):
-        compressed = (1 + 2 / np.pi * np.arctan((image - self.center) * self.get_scale())) * self.dynamic_range / 2
+        compressed = (
+            (1 + 2 / np.pi * np.arctan((image - self.center) * self.get_scale()))
+            * self.dynamic_range
+            / 2
+        )
 
         return self.quantize(compressed)
 
@@ -133,6 +155,95 @@ class ClipCompander(Compander):
         return scaled / self.get_scale() + self.center
 
 
+def get_companders(args):
+    """Return all available companders initialized from compression arguments."""
+    dynamic_range = 2 ** args.compress_bits - 1
+
+    return [
+        ("tanh", TanhCompander(args.compress_center, args.compress_delta, dynamic_range)),
+        ("arctan", ArctanCompander(args.compress_center, args.compress_delta, dynamic_range)),
+        (
+            "reciprocal square root",
+            RecipSqRootCompander(args.compress_center, args.compress_delta, dynamic_range)
+        ),
+        ("clip", ClipCompander(args.compress_center, args.compress_delta, dynamic_range)),
+    ]
+
+
+def show_compander_results(args, image, colormap="gray", show=True):
+    """Show compressed *image* results for every compander."""
+    import matplotlib.pyplot as plt
+
+    companders = get_companders(args)
+    fig, axes = plt.subplots(
+        2,
+        2,
+        figsize=(8, 8),
+        constrained_layout=True,
+        squeeze=False
+    )
+    axes = axes.ravel()
+    color_image = None
+
+    for ax, (name, compander) in zip(axes, companders):
+        compressed = compander.compress(image)
+        color_image = ax.imshow(
+            compressed,
+            cmap=colormap,
+            vmin=0,
+            vmax=compander.dynamic_range
+        )
+        ax.set_title(name)
+        ax.axis("off")
+
+    fig.colorbar(color_image, ax=axes.tolist())
+
+    if show:
+        plt.show()
+
+    return fig
+
+
+def show_compander_tone_curves(args, num_points=1024, show=True):
+    """Show tone curves for every compander."""
+    import matplotlib.pyplot as plt
+
+    companders = get_companders(args)
+    dynamic_range = 2 ** args.compress_bits - 1
+    span = dynamic_range * args.compress_delta
+    values = np.linspace(
+        args.compress_center - span / 2,
+        args.compress_center + span / 2,
+        num_points
+    )
+    soft_mask = (args.compress_softmin <= values) & (values <= args.compress_softmax)
+    fig, ax = plt.subplots(figsize=(8, 6), constrained_layout=True)
+
+    for name, compander in companders:
+        line, = ax.plot(values, compander.compress(values), alpha=0.25)
+        color = line.get_color()
+        if np.any(soft_mask):
+            ax.plot(
+                values[soft_mask],
+                compander.compress(values[soft_mask]),
+                color=color,
+                label=name,
+                linewidth=2
+            )
+
+    ax.axvline(args.compress_softmin, color="0.4", linestyle="--", linewidth=1)
+    ax.axvline(args.compress_softmax, color="0.4", linestyle="--", linewidth=1)
+    ax.set_xlabel("Input value")
+    ax.set_ylabel("Compressed value")
+    ax.grid(True)
+    ax.legend()
+
+    if show:
+        plt.show()
+
+    return fig
+
+
 def optimize_delta_to_sigma(args, sigma, images):
     dynamic_range = 2 ** args.compress_bits - 1
 
@@ -148,9 +259,9 @@ def optimize_delta_to_sigma(args, sigma, images):
             compressed = compander.compress(image).astype(get_uint_dtype(dynamic_range))
             reco = compander.expand(compressed)
             rmses.append(get_rmse(image, reco))
-            
+
         return np.mean(rmses)
-    
+
     res = minimize_scalar(
         obj_func,
         bounds=(sigma / 20, 10 * sigma),
@@ -159,7 +270,7 @@ def optimize_delta_to_sigma(args, sigma, images):
     )
     LOG.debug("Optimized delta / sigma: %.2f", res.x / sigma)
     LOG.debug("Optimized RMSE / sigma after quantization: %.2f", res.fun / sigma)
-    
+
     return res.x
 
 
@@ -194,7 +305,10 @@ def analyze(args, images):
         rmse_full.append(get_rmse(image, expanded_full))
         tifffile.imwrite("/mnt/fast3/compression/original.tif", image.astype(np.float32))
         tifffile.imwrite("/mnt/fast3/compression/expanded.tif", expanded.astype(np.float32))
-        tifffile.imwrite("/mnt/fast3/compression/compressed-orig.tif", expanded_full.astype(np.float32))
+        tifffile.imwrite(
+            "/mnt/fast3/compression/compressed-orig.tif",
+            expanded_full.astype(np.float32)
+        )
         # tifffile.imwrite(
         #     "/mnt/fast3/compression/compressed.tif",
         #     compressed.astype(get_uint_dtype(dynamic_range)),
@@ -211,8 +325,14 @@ def analyze(args, images):
         "Required dynamic range for given delta: %d",
         int(np.ceil(input_span / args.compress_delta)),
     )
-    LOG.debug("Data sigma / compress delta: %.2f (should be > 1)", sigma / args.compress_delta)
-    LOG.debug("Dynamic range / soft data dynamic range: %.2f (should be > 1)", delta_span / input_span)
+    LOG.debug(
+        "Data sigma / compress delta: %.2f (should be > 1)",
+        sigma / args.compress_delta
+    )
+    LOG.debug(
+        "Dynamic range / soft data dynamic range: %.2f (should be > 1)",
+        delta_span / input_span
+    )
     max_soft_deviation = max(
         compander.get_linearity_deviation(args.compress_softmin),
         compander.get_linearity_deviation(args.compress_softmax),
@@ -242,20 +362,22 @@ def analyze(args, images):
 
 
 def compress(args):
-    dynamic_range = 2 ** args.compress_bits - 1
     images = read_image(
         args.images, image_start=args.image_start, image_step=args.image_step, allow_multi=True
     )
     sigma = None
     side = np.minimum(images.shape[-1], images.shape[-2])
     inner_side = int(side / np.sqrt(2))
-    margin = side - inner_side
     images = images[
         :,
         (images.shape[1] - inner_side) // 2:-(images.shape[1] - inner_side) // 2,
         (images.shape[2] - inner_side) // 2:-(images.shape[2] - inner_side) // 2
     ]
-    if args.compress_softmin is None or args.compress_softmax is None or args.compress_center is None:
+    if (
+        args.compress_softmin is None
+        or args.compress_softmax is None
+        or args.compress_center is None
+    ):
         softmin, center, softmax = np.percentile(
             images,
             (args.compress_input_percentile, 50, 100 - args.compress_input_percentile)
@@ -278,7 +400,9 @@ def compress(args):
         args.compress_j2k_rmse = sigma / 4
 
     analyze(args, images)
-    
+    show_compander_results(args, images[0], show=False)
+    show_compander_tone_curves(args, show=True)
+
 
 def decompress(args):
     pass

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -746,7 +746,7 @@ def create_compression_pipeline(args, direction='forward', processing_node=None)
 
 def set_compression_aware_denoise_props(args):
     """Set denoising parameters from the compression delta."""
-    denoise_sigma = np.sqrt(0.5) * args.compress_delta
+    denoise_sigma = args.compress_delta
     args.denoise_h = denoise_sigma
     args.denoise_sigma = denoise_sigma
     args.denoise_estimate_sigma = False

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -1,0 +1,154 @@
+from abc import ABC, abstractmethod
+import logging
+
+import numpy as np
+from tofu.util import read_image
+from tofu.metrics import get_sigma, get_psnr, get_rmse
+
+LOG = logging.getLogger(__name__)
+
+__all__ = ["ArctanCompander", "Compander", "TanhCompander", "compress", "decompress"]
+
+
+def get_uint_dtype(dynamic_range):
+    """Return the smallest unsigned integer dtype that can store *dynamic_range*."""
+    if dynamic_range <= np.iinfo(np.uint8).max:
+        return np.uint8
+    if dynamic_range <= np.iinfo(np.uint16).max:
+        return np.uint16
+
+    raise ValueError("data range does not fit into uint16")
+
+
+class Compander(ABC):
+    """Base class for reversible dynamic range companders."""
+
+    def __init__(self, center, input_span, quantized_span, output_percentile, dynamic_range):
+        self.center = center
+        self.input_span = input_span
+        self.quantized_span = quantized_span
+        self.output_percentile = output_percentile
+        self.dynamic_range = dynamic_range
+
+    @abstractmethod
+    def compress(self, image):
+        """Compress the dynamic range of *image*."""
+
+    @abstractmethod
+    def expand(self, image):
+        """Expand a previously compressed *image*."""
+
+    @abstractmethod
+    def get_scale(self):
+        """Get compander scale factor that maps input to quantized dynamic range."""
+
+
+class TanhCompander(Compander):
+    """Compress and expand values using a hyperbolic tangent curve."""
+
+    def get_scale(self):
+        return 2 * np.arctanh(self.output_percentile) / self.quantized_span
+    
+    def compress(self, image):
+        return 0.5 * (1 + np.tanh((image - self.center) * self.get_scale())) * self.dynamic_range
+
+    def expand(self, image):
+        limit = np.nextafter(1.0, 0.0)
+        scaled = np.clip(2 * image.astype(float) / self.dynamic_range - 1, -limit, limit)
+
+        return np.arctanh(scaled) / self.get_scale() + self.center
+
+
+class ArctanCompander(Compander):
+    """Compress and expand values using an arctangent curve."""
+
+    def compress(self, image):
+        normalized = self._normalize(image)
+        compressed = np.arctan(self.strength * normalized) / np.arctan(self.strength)
+
+        return self._denormalize(compressed)
+
+    def expand(self, image):
+        normalized = self._normalize(image)
+        expanded = np.tan(normalized * np.arctan(self.strength)) / self.strength
+
+        return self._denormalize(expanded)
+
+
+def analyze(args, minimum, maximum):
+    input_span = maximum - minimum
+    dynamic_range = 2 ** args.compress_bits - 1
+    delta_span = dynamic_range * args.compress_delta
+
+    LOG.debug("Compression info")
+    LOG.debug("Center: %g", args.compress_center)
+    LOG.debug("Noise sigma: %g", args.compress_sigma)
+    LOG.debug("Compress delta: %g", args.compress_delta)
+    LOG.debug(
+        "Required dynamic range for given delta: %d",
+        int(np.ceil(input_span / args.compress_delta)),
+    )
+    LOG.debug("Data span for percentile %g: %g", args.compress_input_percentile, input_span)
+    LOG.debug(
+        "Possible span for dynamic range %d and compress delta %g: %g",
+        dynamic_range,
+        args.compress_delta,
+        delta_span
+    )
+    LOG.debug("Data sigma / compress delta: %.2f (should be > 1)", args.compress_sigma / args.compress_delta)
+    LOG.debug("Possible span / data span: %.2f (should be > 1)", delta_span / input_span)
+
+
+def compress(args):
+    dynamic_range = 2 ** args.compress_bits - 1
+    images = read_image(
+        args.images, image_start=args.image_start, image_step=args.image_step, allow_multi=True
+    )
+    side = np.minimum(images.shape[-1], images.shape[-2])
+    inner_side = int(side / np.sqrt(2))
+    margin = side - inner_side
+    images = images[
+        :,
+        (images.shape[1] - inner_side) // 2:-(images.shape[1] - inner_side) // 2,
+        (images.shape[2] - inner_side) // 2:-(images.shape[2] - inner_side) // 2
+    ]
+    minimum, center, maximum = np.percentile(
+        images,
+        (args.compress_input_percentile, 50, 100 - args.compress_input_percentile)
+    )
+    if not args.compress_sigma:
+        args.compress_sigma = np.median([get_sigma(image) for image in images])
+
+    if args.compress_center is None:
+        args.compress_center = center
+
+    if not args.compress_delta:
+        args.compress_delta = args.compress_sigma / 4
+
+    analyze(args, minimum, maximum)
+
+    compander = TanhCompander(
+        args.compress_center,
+        maximum - minimum,
+        args.compress_delta * dynamic_range,
+        args.compress_output_percentile / 100,
+        dynamic_range
+    )
+    im = images[0]
+    #compressed = compander.compress(im)
+    #expanded = compander.expand(compressed)
+    #print(get_rmse(im, expanded) / args.compress_sigma)
+    linear_range = np.arange(dynamic_range + 1)
+    input_range = (linear_range - (dynamic_range + 1) / 2.0) * args.compress_delta
+    compressed_range = compander.compress(input_range)
+
+    print(np.tanh(args.compress_delta * dynamic_range * compander.get_scale() / 2))
+    print(compander.compress(args.compress_delta * dynamic_range / 2))
+    print(compander.compress(input_range))
+    import matplotlib.pyplot as plt
+    plt.plot(compressed_range)
+    plt.show()
+
+
+def decompress(args):
+    pass

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -20,6 +20,8 @@ __all__ = [
     "RecipSqRootCompander",
     "TanhCompander",
     "compress",
+    "configure_output_writer",
+    "create_output_processing_pipeline",
     "decompress",
     "get_companders",
     "get_uint_dtype",
@@ -742,6 +744,70 @@ def create_compression_pipeline(args, direction='forward', processing_node=None)
         args.compress_delta,
         dynamic_range
     ).create_ufo_task(direction=direction, processing_node=processing_node)
+
+
+def get_output_jpeg2000_level(args):
+    """Return the JPEG 2000 level for companded reconstruction output."""
+    if getattr(args, 'compress_j2k_rmse', None) is None:
+        return 0
+
+    return int(round(get_jpeg2000_level(
+        args.compress_delta * (2 ** args.compress_bits - 1),
+        args.compress_j2k_rmse
+    )))
+
+
+def validate_output_compression_args(args):
+    """Validate parameters which cannot be inferred before reconstruction."""
+    if args.compress_center is None:
+        raise RuntimeError('--compress-center must be specified with --compress-output')
+    if args.compress_delta is None:
+        raise RuntimeError('--compress-delta must be specified with --compress-output')
+
+
+def configure_output_writer(writer, args):
+    """Configure a UFO writer for companded JPEG 2000 TIFF output."""
+    if not getattr(args, 'compress_output', False) or getattr(args, 'dry_run', False):
+        return
+
+    validate_output_compression_args(args)
+    if not hasattr(writer.props, 'tiff_jpeg2000'):
+        raise RuntimeError('The UFO writer does not support JPEG 2000-compressed TIFF output')
+
+    writer.props.bits = args.compress_bits
+    writer.props.rescale = False
+    writer.props.tiff_jpeg2000 = True
+    writer.props.level = get_output_jpeg2000_level(args)
+
+
+def create_output_processing_pipeline(args, graph, current, processing_node=None):
+    """Append optional denoising and companding to reconstruction output."""
+    if getattr(args, 'denoise', False):
+        if getattr(args, 'denoise_compression_aware', False):
+            if not getattr(args, 'compress_output', False):
+                raise RuntimeError(
+                    '--denoise-compression-aware requires --compress-output'
+                )
+            validate_output_compression_args(args)
+            set_compression_aware_denoise_props(args)
+
+        denoise = create_denoising_pipeline(args, processing_node=processing_node)
+        graph.connect_nodes(current, denoise)
+        current = denoise
+
+    if getattr(args, 'compress_output', False):
+        validate_output_compression_args(args)
+        dynamic_range = 2 ** args.compress_bits - 1
+        compander_cls = COMPANDER_TYPES[getattr(args, 'compress_compander', 'tanh')]
+        compand = compander_cls(
+            args.compress_center,
+            args.compress_delta,
+            dynamic_range
+        ).create_ufo_task(processing_node=processing_node)
+        graph.connect_nodes(current, compand)
+        current = compand
+
+    return current
 
 
 def set_compression_aware_denoise_props(args):

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -23,7 +23,9 @@ __all__ = [
     "decompress",
     "get_companders",
     "get_uint_dtype",
+    "show_compander_results_pyqtgraph",
     "show_compander_results",
+    "show_compander_tone_curves_pyqtgraph",
     "show_compander_tone_curves",
 ]
 
@@ -36,6 +38,14 @@ def get_uint_dtype(dynamic_range):
         return np.uint16
 
     raise ValueError("data range does not fit into uint16")
+
+
+def run_qt_app(app):
+    """Run a Qt application across PyQt versions."""
+    if hasattr(app, 'exec'):
+        return app.exec()
+
+    return app.exec_()
 
 
 class Compander(ABC):
@@ -268,6 +278,162 @@ def show_compander_results(args, image, hardmin=None, hardmax=None, colormap="gr
     return fig
 
 
+def show_compander_results_pyqtgraph(args, image, hardmin=None, hardmax=None, colormap="gray", show=True):
+    """Show compressed *image* result for the selected compander using pyqtgraph."""
+    import pyqtgraph
+    from PyQt5 import QtCore, QtWidgets
+
+    pyqtgraph.setConfigOptions(antialias=True, imageAxisOrder='row-major')
+
+    compander_name = getattr(args, 'compress_compander', 'tanh')
+    dynamic_range = 2 ** args.compress_bits - 1
+    compander = COMPANDER_TYPES[compander_name](
+        args.compress_center,
+        args.compress_delta,
+        dynamic_range
+    )
+    compressed = compander.compress(image)
+    compressed_softmin, compressed_softmax = np.percentile(compressed, (0.01, 99.99))
+
+    app = QtWidgets.QApplication.instance()
+    owns_app = app is None
+    if owns_app:
+        app = QtWidgets.QApplication([])
+
+    view = pyqtgraph.ImageView(view=pyqtgraph.PlotItem())
+    view.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+    view.setWindowTitle("{} compander".format(compander_name))
+    view.getView().setAspectLocked(True)
+    view.setImage(
+        compressed,
+        autoRange=True,
+        autoLevels=False,
+        levels=(compressed_softmin, compressed_softmax)
+    )
+
+    if hasattr(view.ui, 'roiBtn'):
+        view.ui.roiBtn.hide()
+    if hasattr(view.ui, 'menuBtn'):
+        view.ui.menuBtn.hide()
+
+    image_item = view.getImageItem()
+    plot_item = view.getView()
+    default_title = "{} compander".format(compander_name)
+    plot_item.setTitle(default_title)
+
+    def update_mouse_position(event):
+        if not image_item.sceneBoundingRect().contains(event):
+            plot_item.setTitle(default_title)
+            return
+
+        pos = image_item.mapFromScene(event)
+        x = int(pos.x() + 0.5)
+        y = int(pos.y() + 0.5)
+        if 0 <= y < compressed.shape[0] and 0 <= x < compressed.shape[1]:
+            plot_item.setTitle("x={}, y={}, I={:g}".format(x, y, compressed[y, x]))
+        else:
+            plot_item.setTitle(default_title)
+
+    mouse_proxy = pyqtgraph.SignalProxy(
+        image_item.scene().sigMouseMoved,
+        rateLimit=60,
+        slot=lambda event: update_mouse_position(event[0])
+    )
+
+    view._tofu_qapp = app
+    view._tofu_mouse_proxy = mouse_proxy
+    if show:
+        view.show()
+        if owns_app:
+            run_qt_app(app)
+
+    return view
+
+
+def show_compander_tone_curves_pyqtgraph(
+        args, softmin, softmax, hardmin, hardmax, num_points=1024, show=True):
+    """Show tone curves for every compander using pyqtgraph."""
+    import pyqtgraph
+    from PyQt5 import QtCore, QtWidgets
+
+    pyqtgraph.setConfigOptions(antialias=True, background='w', foreground='k')
+
+    app = QtWidgets.QApplication.instance()
+    owns_app = app is None
+    if owns_app:
+        app = QtWidgets.QApplication([])
+
+    companders = get_companders(args)
+    values = np.linspace(hardmin, hardmax, num=num_points)
+    soft_mask = (softmin <= values) & (values <= softmax)
+    curves = [(name, compander.compress(values, quantize=False)) for name, compander in companders]
+    y_min = min(np.min(curve) for _, curve in curves)
+    y_max = max(np.max(curve) for _, curve in curves)
+    if y_min == y_max:
+        y_max = y_min + 1
+
+    plot = pyqtgraph.PlotWidget(title="Compander tone curves")
+    plot.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+    plot.setWindowTitle("Compander tone curves")
+    plot.setLabel("bottom", "Input value")
+    plot.setLabel("left", "Quantized value")
+    plot.showGrid(x=False, y=False)
+    plot.addLegend()
+
+    for index, (name, curve) in enumerate(curves):
+        color = pyqtgraph.intColor(index, hues=len(curves), minValue=80, maxValue=200)
+        plot.plot(values, curve, pen=pyqtgraph.mkPen(color, width=1))
+        if np.any(soft_mask):
+            plot.plot(
+                values[soft_mask],
+                curve[soft_mask],
+                pen=pyqtgraph.mkPen(color, width=3),
+                name=name
+            )
+
+    center_pen = pyqtgraph.mkPen((0, 0, 0), width=3, style=QtCore.Qt.DashLine)
+    soft_pen = pyqtgraph.mkPen((40, 110, 220), width=2, style=QtCore.Qt.DotLine)
+    hard_pen = pyqtgraph.mkPen((180, 60, 40), width=2, style=QtCore.Qt.DashLine)
+    plot.plot([args.compress_center, args.compress_center], [y_min, y_max], pen=center_pen, name="center")
+    plot.plot([softmin, softmin], [y_min, y_max], pen=soft_pen, name="softmin/softmax")
+    plot.plot([softmax, softmax], [y_min, y_max], pen=soft_pen)
+    plot.plot([hardmin, hardmin], [y_min, y_max], pen=hard_pen, name="hardmin/hardmax")
+    plot.plot([hardmax, hardmax], [y_min, y_max], pen=hard_pen)
+
+    plot.setXRange(hardmin, hardmax, padding=0.02)
+    plot.setYRange(y_min, y_max, padding=0.05)
+
+    def update_mouse_position(event):
+        plot_item = plot.getPlotItem()
+        if not plot_item.sceneBoundingRect().contains(event):
+            plot_item.setTitle("Compander tone curves")
+            return
+
+        pos = plot_item.vb.mapSceneToView(event)
+        x = pos.x()
+        y = pos.y()
+        if hardmin <= x <= hardmax and y_min <= y <= y_max:
+            plot_item.setTitle("x={:g}, y={:g}".format(x, y))
+        else:
+            plot_item.setTitle("Compander tone curves")
+
+    mouse_proxy = pyqtgraph.SignalProxy(
+        plot.scene().sigMouseMoved,
+        rateLimit=60,
+        slot=lambda event: update_mouse_position(event[0])
+    )
+
+    plot._tofu_qapp = app
+    plot._tofu_mouse_proxy = mouse_proxy
+
+    if show:
+        plot.show()
+        if owns_app:
+            run_qt_app(app)
+
+    return plot
+
+
 def show_compander_tone_curves(args, softmin, softmax, hardmin, hardmax, num_points=1024, show=True):
     """Show tone curves for every compander."""
     import matplotlib.pyplot as plt
@@ -445,8 +611,32 @@ def analyze(args, images):
     LOG.debug("RMSE / sigma of all steps: %.2f", np.mean(rmse_full) / sigma)
 
     if args.compress_visualize:
-        show_compander_results(args, images[images.shape[0] // 2], hardmin, hardmax, show=False)
-        show_compander_tone_curves(args, softmin, softmax, hardmin, hardmax, show=True)
+        from PyQt5 import QtWidgets
+
+        app = QtWidgets.QApplication.instance()
+        owns_app = app is None
+        if owns_app:
+            app = QtWidgets.QApplication([])
+
+        image_view = show_compander_results_pyqtgraph(
+            args,
+            images[images.shape[0] // 2],
+            hardmin,
+            hardmax,
+            show=False
+        )
+        tone_curves = show_compander_tone_curves_pyqtgraph(
+            args,
+            softmin,
+            softmax,
+            hardmin,
+            hardmax,
+            show=False
+        )
+        image_view.show()
+        tone_curves.show()
+        if owns_app:
+            run_qt_app(app)
 
 
 def determine_compression_parameters(args):

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -43,13 +43,18 @@ class Compander(ABC):
         self.delta = delta
         self.dynamic_range = dynamic_range
 
-    def get_scale(self):
-        """Get compander scale factor that maps input to quantized dynamic range."""
+    @property
+    def scale_factor(self):
+        """Compander scale factor that maps input to quantized dynamic range."""
         return 2 / (self.delta * self.dynamic_range)
 
-    def compress(self, image):
+    def compress(self, image, quantize=True):
         """Compress the dynamic range of *image*."""
-        return self.quantize((1 + self.scale(image)) / 2 * self.dynamic_range)
+        compressed = (1 + self.scale(image)) / 2 * self.dynamic_range
+        if quantize:
+            compressed = self.quantize(compressed)
+
+        return compressed
 
     @abstractmethod
     def scale(self, image):
@@ -71,30 +76,35 @@ class TanhCompander(Compander):
     """Compress and expand values using a hyperbolic tangent curve."""
 
     def get_linearity_deviation(self, value):
-        scaled = (value - self.center) * self.get_scale()
+        scaled = (value - self.center) * self.scale_factor
         return np.abs(scaled / 2 - np.tanh(scaled) / 2) * self.dynamic_range
 
     def scale(self, image):
-        return np.tanh((image - self.center) * self.get_scale())
+        return np.tanh((image - self.center) * self.scale_factor)
 
     def expand(self, image):
         limit = np.nextafter(1.0, 0.0)
         scaled = np.clip(2 * image.astype(float) / self.dynamic_range - 1, -limit, limit)
 
-        return np.arctanh(scaled) / self.get_scale() + self.center
+        return np.arctanh(scaled) / self.scale_factor + self.center
 
 
 class ArctanCompander(Compander):
     """Compress and expand values using an arctangent curve."""
 
+    @property
+    def scale_factor(self):
+        """Get compander scale factor that maps input to quantized dynamic range."""
+        return np.pi / (self.delta * self.dynamic_range)
+
     def get_linearity_deviation(self, value):
-        scaled = (value - self.center) * self.get_scale()
+        scaled = (value - self.center) * self.scale_factor
         deviation = scaled / 2 - 2 / np.pi * np.arctan(scaled) / 2
 
         return np.abs(deviation) * self.dynamic_range
 
     def scale(self, image):
-        return 2 / np.pi * np.arctan((image - self.center) * self.get_scale())
+        return 2 / np.pi * np.arctan((image - self.center) * self.scale_factor)
 
     def expand(self, image):
         limit = np.nextafter(np.pi / 2, 0.0)
@@ -104,42 +114,42 @@ class ArctanCompander(Compander):
             limit
         )
 
-        return np.tan(scaled) / self.get_scale() + self.center
+        return np.tan(scaled) / self.scale_factor + self.center
 
 
 class RecipSqRootCompander(Compander):
     """Compress and expand values using the x / sqrt(1 + x^2) function."""
 
     def get_linearity_deviation(self, value):
-        scaled = (value - self.center) * self.get_scale()
+        scaled = (value - self.center) * self.scale_factor
         return np.abs(scaled / 2 - scaled / np.sqrt(1 + scaled ** 2) / 2) * self.dynamic_range
 
     def scale(self, image):
-        scaled = (image - self.center) * self.get_scale()
+        scaled = (image - self.center) * self.scale_factor
         return scaled / np.sqrt(1 + scaled ** 2)
 
     def expand(self, image):
         limit = np.nextafter(1.0, 0.0)
         scaled = np.clip(2 * image.astype(float) / self.dynamic_range - 1, -limit, limit)
 
-        return scaled / np.sqrt(1 - scaled ** 2) / self.get_scale() + self.center
+        return scaled / np.sqrt(1 - scaled ** 2) / self.scale_factor + self.center
 
 
 class ClipCompander(Compander):
     """Compress and expand values using the x / sqrt(1 + x^2) function."""
 
     def get_linearity_deviation(self, value):
-        scaled = (value - self.center) * self.get_scale()
+        scaled = (value - self.center) * self.scale_factor
         return np.abs(scaled / 2 - scaled / np.sqrt(1 + scaled ** 2) / 2) * self.dynamic_range
 
     def scale(self, image):
-        return np.clip((image - self.center) * self.get_scale(), -1, 1)
+        return np.clip((image - self.center) * self.scale_factor, -1, 1)
 
     def expand(self, image):
         limit = np.nextafter(1.0, 0.0)
         scaled = np.clip(2 * image.astype(float) / self.dynamic_range - 1, -limit, limit)
 
-        return scaled / self.get_scale() + self.center
+        return scaled / self.scale_factor + self.center
 
 
 def get_companders(args):
@@ -191,37 +201,58 @@ def show_compander_results(args, image, colormap="gray", show=True):
     return fig
 
 
-def show_compander_tone_curves(args, num_points=1024, show=True):
+def show_compander_tone_curves(args, hardmin, hardmax, num_points=1024, show=True):
     """Show tone curves for every compander."""
     import matplotlib.pyplot as plt
 
     companders = get_companders(args)
-    dynamic_range = 2 ** args.compress_bits - 1
-    span = dynamic_range * args.compress_delta
-    values = np.linspace(
-        args.compress_center - span / 2,
-        args.compress_center + span / 2,
-        num_points
-    )
+
+    values = np.linspace(hardmin, hardmax, num=num_points)
     soft_mask = (args.compress_softmin <= values) & (values <= args.compress_softmax)
     fig, ax = plt.subplots(figsize=(8, 6), constrained_layout=True)
 
     for name, compander in companders:
-        line, = ax.plot(values, compander.scale(values), alpha=0.25)
+        line, = ax.plot(values, compander.compress(values, quantize=False), alpha=0.5)
         color = line.get_color()
         if np.any(soft_mask):
             ax.plot(
                 values[soft_mask],
-                compander.scale(values[soft_mask]),
+                compander.compress(values[soft_mask], quantize=False),
                 color=color,
                 label=name,
                 linewidth=2
             )
 
-    ax.axvline(args.compress_softmin, color="0.4", linestyle="--", linewidth=1)
-    ax.axvline(args.compress_softmax, color="0.4", linestyle="--", linewidth=1)
+    ax.axvline(
+        args.compress_center,
+        color="black",
+        linestyle="-.",
+        linewidth=1,
+        label="center"
+    )
+    ax.axvline(args.compress_softmin, color="0.4", linestyle=":", linewidth=1)
+    ax.axvline(
+        args.compress_softmax,
+        color="0.4",
+        linestyle=":",
+        linewidth=1,
+        label="softmin/softmax"
+    )
+    ax.axvline(
+        hardmin,
+        color="0.2",
+        linestyle="--",
+        linewidth=1,
+    )
+    ax.axvline(
+        hardmax,
+        color="0.2",
+        linestyle="--",
+        linewidth=1,
+        label="hardmin/hardmax"
+    )
     ax.set_xlabel("Input value")
-    ax.set_ylabel("Compressed value")
+    ax.set_ylabel("Quantized value")
     ax.grid(True)
     ax.legend()
 
@@ -388,7 +419,8 @@ def compress(args):
 
     analyze(args, images)
     # show_compander_results(args, images[0], show=False)
-    show_compander_tone_curves(args, show=True)
+    hardmin, hardmax = np.percentile(images, (0, 100))
+    show_compander_tone_curves(args, hardmin, hardmax, show=True)
 
 
 def decompress(args):

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -687,7 +687,8 @@ def determine_compression_parameters(args):
         args.compress_delta = max(sigma / 4, optimize_delta_to_sigma(args, sigma, images))
         LOG.debug("--compress-delta calculated: %g", args.compress_delta)
     if args.compress_j2k_rmse is None:
-        sigma = np.median([get_sigma(image) for image in images])
+        if sigma is None:
+            sigma = np.median([get_sigma(image) for image in images])
         # j2k RMSE wrt original noise sigma is 1/4
         args.compress_j2k_rmse = sigma / 4
         LOG.debug("--compress-j2k-rmse calculated using 1 / 4 of noise sigma: %g", args.compress_j2k_rmse)
@@ -725,6 +726,15 @@ def create_compression_pipeline(args, direction='forward', processing_node=None)
     ).create_ufo_task(direction=direction, processing_node=processing_node)
 
 
+def set_compression_aware_denoise_props(args):
+    """Set denoising parameters from the compression delta."""
+    denoise_sigma = np.sqrt(0.5) * args.compress_delta
+    args.denoise_h = denoise_sigma
+    args.denoise_sigma = denoise_sigma
+    args.denoise_estimate_sigma = False
+    LOG.info("Denoise h and sigma from compression delta: %g", denoise_sigma)
+
+
 def compress(args):
     """Run image compression using a UFO companding pipeline."""
     compand = create_compression_pipeline(args)
@@ -757,6 +767,8 @@ def compress(args):
 
     current = reader
     if getattr(args, 'denoise', False):
+        if getattr(args, 'denoise_compression_aware', False):
+            set_compression_aware_denoise_props(args)
         denoise = create_denoising_pipeline(args)
         graph.connect_nodes(current, denoise)
         current = denoise

--- a/tofu/compress.py
+++ b/tofu/compress.py
@@ -280,8 +280,14 @@ def show_compander_results(args, image, hardmin=None, hardmax=None, colormap="gr
 
 def show_compander_results_pyqtgraph(args, image, hardmin=None, hardmax=None, colormap="gray", show=True):
     """Show compressed *image* result for the selected compander using pyqtgraph."""
-    import pyqtgraph
     from PyQt5 import QtCore, QtWidgets
+
+    app = QtWidgets.QApplication.instance()
+    owns_app = app is None
+    if owns_app:
+        app = QtWidgets.QApplication([])
+
+    import pyqtgraph
 
     pyqtgraph.setConfigOptions(antialias=True, imageAxisOrder='row-major')
 
@@ -294,11 +300,6 @@ def show_compander_results_pyqtgraph(args, image, hardmin=None, hardmax=None, co
     )
     compressed = compander.compress(image)
     compressed_softmin, compressed_softmax = np.percentile(compressed, (0.01, 99.99))
-
-    app = QtWidgets.QApplication.instance()
-    owns_app = app is None
-    if owns_app:
-        app = QtWidgets.QApplication([])
 
     view = pyqtgraph.ImageView(view=pyqtgraph.PlotItem())
     view.setAttribute(QtCore.Qt.WA_DeleteOnClose)
@@ -320,28 +321,42 @@ def show_compander_results_pyqtgraph(args, image, hardmin=None, hardmax=None, co
     plot_item = view.getView()
     default_title = "{} compander".format(compander_name)
     plot_item.setTitle(default_title)
+    readout = pyqtgraph.TextItem(default_title, color='w', anchor=(0.5, 0), fill=(0, 0, 0, 160))
+    readout.setZValue(10)
+    plot_item.addItem(readout, ignoreBounds=True)
+
+    def update_readout_position():
+        x_range, y_range = plot_item.vb.viewRange()
+        y_span = y_range[1] - y_range[0]
+        readout.setPos((x_range[0] + x_range[1]) / 2, y_range[0] + 0.01 * y_span)
+
+    update_readout_position()
+    update_readout_position_callback = lambda *args: update_readout_position()
+    plot_item.vb.sigRangeChanged.connect(update_readout_position_callback)
 
     def update_mouse_position(event):
         if not image_item.sceneBoundingRect().contains(event):
             plot_item.setTitle(default_title)
+            readout.setText(default_title)
             return
 
         pos = image_item.mapFromScene(event)
         x = int(pos.x() + 0.5)
         y = int(pos.y() + 0.5)
         if 0 <= y < compressed.shape[0] and 0 <= x < compressed.shape[1]:
-            plot_item.setTitle("x={}, y={}, I={:g}".format(x, y, compressed[y, x]))
+            title = "x={}, y={}, I={:g}".format(x, y, compressed[y, x])
+            plot_item.setTitle(title)
+            readout.setText(title)
         else:
             plot_item.setTitle(default_title)
+            readout.setText(default_title)
 
-    mouse_proxy = pyqtgraph.SignalProxy(
-        image_item.scene().sigMouseMoved,
-        rateLimit=60,
-        slot=lambda event: update_mouse_position(event[0])
-    )
+    image_item.scene().sigMouseMoved.connect(update_mouse_position)
 
     view._tofu_qapp = app
-    view._tofu_mouse_proxy = mouse_proxy
+    view._tofu_mouse_callback = update_mouse_position
+    view._tofu_mouse_readout = readout
+    view._tofu_readout_position_callback = update_readout_position_callback
     if show:
         view.show()
         if owns_app:
@@ -353,15 +368,16 @@ def show_compander_results_pyqtgraph(args, image, hardmin=None, hardmax=None, co
 def show_compander_tone_curves_pyqtgraph(
         args, softmin, softmax, hardmin, hardmax, num_points=1024, show=True):
     """Show tone curves for every compander using pyqtgraph."""
-    import pyqtgraph
     from PyQt5 import QtCore, QtWidgets
-
-    pyqtgraph.setConfigOptions(antialias=True, background='w', foreground='k')
 
     app = QtWidgets.QApplication.instance()
     owns_app = app is None
     if owns_app:
         app = QtWidgets.QApplication([])
+
+    import pyqtgraph
+
+    pyqtgraph.setConfigOptions(antialias=True, background='w', foreground='k')
 
     companders = get_companders(args)
     values = np.linspace(hardmin, hardmax, num=num_points)

--- a/tofu/config.py
+++ b/tofu/config.py
@@ -865,6 +865,10 @@ SECTIONS['compress'] = {
         'type': int,
         'choices': [8, 16],
         'help': "Output dynamic range in bits"},
+    'compress-compander': {
+        'default': 'tanh',
+        'choices': ['tanh', 'arctan', 'recip_sqrt', 'clip'],
+        'help': "Compander curve"},
     'compress-delta': {
         'default': None,
         'type': float,

--- a/tofu/config.py
+++ b/tofu/config.py
@@ -921,10 +921,6 @@ SECTIONS['denoise'] = {
         'default': False,
         'action': 'store_true',
         'help': "Use Gaussian window by computing patch weights"},
-    'denoise-fast': {
-        'default': False,
-        'action': 'store_true',
-        'help': "Use a faster version of the algorithm"},
     'denoise-estimate-sigma': {
         'default': False,
         'action': 'store_true',

--- a/tofu/config.py
+++ b/tofu/config.py
@@ -864,32 +864,30 @@ SECTIONS['compress'] = {
         'type': int,
         'choices': [8, 16],
         'help': "Output dynamic range in bits"},
-    'compress-sigma': {
-        'default': None,
-        'type': float,
-        'help': "Noise standard deviation. If not given it will be estimated."},
     'compress-delta': {
         'default': None,
         'type': float,
-        'help': "Delta parameter"},
-    'compress-psnr': {
+        'help': "Grey values spacing"},
+    'compress-j2k-rmse': {
         'default': None,
         'type': float,
-        'help': "PSNR parameter"},
+        'help': "Desired RMSE after conversion to Jpeg2000"},
     'compress-center': {
         'default': None,
         'type': float,
         'help': "Center parameter"},
+    'compress-softmin': {
+        'default': None,
+        'type': float,
+        'help': "Input dynamic range lower value (if not specified determined based on --compress-input-percentile)"},
+    'compress-softmax': {
+        'default': None,
+        'type': float,
+        'help': "Input dynamic range upper value (if not specified determined based on --compress-input-percentile)"},
     'compress-input-percentile': {
         'default': 0.1,
         'type': restrict_value((0, 100)),
-        'help': "Input percentile from 0 to 100 that defines the source dynamic "
-                "range occupied by --output-percentile"},
-    'compress-output-percentile': {
-        'default': 90,
-        'type': restrict_value((0, 100)),
-        'help': "Output percentile from 0 to 100 of a compander's target dynamic range occupied by "
-                "the --input-percentile parameter"},
+        'help': "Input percentile from 0 to 100 that defines softmin and softmax."},
     'compress-auto': {
         'default': False,
         'action': 'store_true',

--- a/tofu/config.py
+++ b/tofu/config.py
@@ -894,14 +894,6 @@ SECTIONS['compress'] = {
         'help': "Automatically determine compression parameters"},
 }
 
-SECTIONS['decompress'] = {
-    'images': {
-        'default': None,
-        'type': str,
-        'help': "Location with input images",
-        'metavar': 'PATH'},
-}
-
 SECTIONS['denoise'] = {
     'denoise-sigma': {
         'default': None,
@@ -933,7 +925,7 @@ NICE_NAMES = ('General', 'Input', 'Flat field correction', 'Phase retrieval',
               'Direct Fourier Inversion', 'Iterative reconstruction',
               'SART', 'SBTV', 'GUI settings', 'Estimation', 'Performance',
               'Preprocess', 'Cone beam weight', 'General reconstruction', 'Find large spots',
-              'Inpaint', 'Compression', 'Decompression', 'Denoising', 'EZ')
+              'Inpaint', 'Compression', 'Denoising', 'EZ')
 
 
 # Add unit info to help strings

--- a/tofu/config.py
+++ b/tofu/config.py
@@ -916,11 +916,11 @@ SECTIONS['denoise'] = {
     'denoise-h': {
         'default': 0.0,
         'type': restrict_value((0, None)),
-        'help': "Smoothing control parameter, should be around noise standard deviation or slightly less; 0 estimates it from the first image"},
+        'help': "Smoothing control parameter, should be around noise standard deviation or slightly less; 0 estimates it from the first image, or uses the compression noise estimate or compression delta in compression mode"},
     'denoise-sigma': {
         'default': 0.0,
         'type': restrict_value((0, None)),
-        'help': "Noise standard deviation; 0 disables explicit noise compensation unless --denoise-estimate-sigma is set"},
+        'help': "Noise standard deviation; 0 disables explicit noise compensation unless --denoise-estimate-sigma is set, or uses the compression noise estimate or compression delta in compression mode"},
     'denoise-window': {
         'default': False,
         'action': 'store_true',

--- a/tofu/config.py
+++ b/tofu/config.py
@@ -914,13 +914,13 @@ SECTIONS['denoise'] = {
         'type': restrict_value((1, 100), dtype=int),
         'help': "Patch radius in pixels"},
     'denoise-h': {
-        'default': 0.1,
+        'default': 0.0,
         'type': restrict_value((0, None)),
-        'help': "Smoothing control parameter, should be around noise standard deviation or slightly less"},
+        'help': "Smoothing control parameter, should be around noise standard deviation or slightly less; 0 estimates it from the first image"},
     'denoise-sigma': {
         'default': 0.0,
         'type': restrict_value((0, None)),
-        'help': "Noise standard deviation"},
+        'help': "Noise standard deviation; 0 disables explicit noise compensation unless --denoise-estimate-sigma is set"},
     'denoise-window': {
         'default': False,
         'action': 'store_true',
@@ -929,6 +929,10 @@ SECTIONS['denoise'] = {
         'default': False,
         'action': 'store_true',
         'help': "Estimate noise standard deviation"},
+    'denoise-compression-aware': {
+        'default': False,
+        'action': 'store_true',
+        'help': "In compression mode, set denoising h and sigma from the compression delta"},
     'denoise-addressing-mode': {
         'choices': ['none', 'clamp', 'clamp_to_edge', 'repeat', 'mirrored_repeat'],
         'default': 'mirrored_repeat',

--- a/tofu/config.py
+++ b/tofu/config.py
@@ -98,6 +98,10 @@ SECTIONS['reading'] = {
         'default': 0,
         'type': restrict_value((0, None), dtype=int),
         'help': 'Offset to the first read file'},
+    'image-start': {
+        'default': 0,
+        'type': restrict_value((0, None), dtype=int),
+        'help': 'Offset to the first read image in a file'},
     'number': {
         'default': None,
         'type': restrict_value((0, None), dtype=int),
@@ -107,6 +111,11 @@ SECTIONS['reading'] = {
         'ezdefault': 1,
         'type': restrict_value((0, None), dtype=int),
         'help': 'Read every \"step\" file'},
+    'image-step': {
+        'default': 1,
+        'ezdefault': 1,
+        'type': restrict_value((0, None), dtype=int),
+        'help': 'Read every \"step\" image from a file'},
     'resize': {
         'default': None,
         'type': restrict_value((0, None), dtype=int),
@@ -844,6 +853,68 @@ SECTIONS['inpaint'] = {
                 "cross in the power spectrum"},
 }
 
+SECTIONS['compress'] = {
+    'images': {
+        'default': None,
+        'type': str,
+        'help': "Location with input images",
+        'metavar': 'PATH'},
+    'compress-bits': {
+        'default': 16,
+        'type': int,
+        'choices': [8, 16],
+        'help': "Output dynamic range in bits"},
+    'compress-sigma': {
+        'default': None,
+        'type': float,
+        'help': "Noise standard deviation. If not given it will be estimated."},
+    'compress-delta': {
+        'default': None,
+        'type': float,
+        'help': "Delta parameter"},
+    'compress-psnr': {
+        'default': None,
+        'type': float,
+        'help': "PSNR parameter"},
+    'compress-center': {
+        'default': None,
+        'type': float,
+        'help': "Center parameter"},
+    'compress-input-percentile': {
+        'default': 0.1,
+        'type': restrict_value((0, 100)),
+        'help': "Input percentile from 0 to 100 that defines the source dynamic "
+                "range occupied by --output-percentile"},
+    'compress-output-percentile': {
+        'default': 90,
+        'type': restrict_value((0, 100)),
+        'help': "Output percentile from 0 to 100 of a compander's target dynamic range occupied by "
+                "the --input-percentile parameter"},
+    'compress-auto': {
+        'default': False,
+        'action': 'store_true',
+        'help': "Automatically determine compression parameters"},
+}
+
+SECTIONS['decompress'] = {
+    'images': {
+        'default': None,
+        'type': str,
+        'help': "Location with input images",
+        'metavar': 'PATH'},
+}
+
+SECTIONS['denoise'] = {
+    'denoise-sigma': {
+        'default': None,
+        'type': float,
+        'help': "Sigma parameter"},
+    'denoise-strength': {
+        'default': None,
+        'type': float,
+        'help': "Denoising strength"},
+}
+
 SECTIONS['ez'] = {
     'ezvars': {
         'default': None,
@@ -864,7 +935,7 @@ NICE_NAMES = ('General', 'Input', 'Flat field correction', 'Phase retrieval',
               'Direct Fourier Inversion', 'Iterative reconstruction',
               'SART', 'SBTV', 'GUI settings', 'Estimation', 'Performance',
               'Preprocess', 'Cone beam weight', 'General reconstruction', 'Find large spots',
-              'Inpaint')
+              'Inpaint', 'Compression', 'Decompression', 'Denoising', 'EZ')
 
 
 # Add unit info to help strings

--- a/tofu/config.py
+++ b/tofu/config.py
@@ -897,6 +897,10 @@ SECTIONS['denoise'] = {
         'type': str,
         'help': "Location with input images",
         'metavar': 'PATH'},
+    'denoise': {
+        'default': False,
+        'action': 'store_true',
+        'help': "Denoise images"},
     'denoise-search-radius': {
         'default': 10,
         'type': restrict_value((1, 8192), dtype=int),
@@ -1039,11 +1043,15 @@ class Params(object):
         self.sections = sections + ('general', 'reading')
     
     def add_parser_args(self, parser):
+        added = set()
         for section in self.sections:
             for name in sorted(SECTIONS[section]):
+                if name in added:
+                    continue
                 opts = without_keys(SECTIONS[section][name], {'ezdefault'})
                 opts.pop('unit', None)
                 parser.add_argument('--{}'.format(name), **opts)
+                added.add(name)
                 
     def add_arguments(self, parser):
         self.add_parser_args(parser)

--- a/tofu/config.py
+++ b/tofu/config.py
@@ -10,6 +10,7 @@ LOG = logging.getLogger(__name__)
 NAME = "reco.conf"
 SECTIONS = OrderedDict()
 
+
 SECTIONS['general'] = {
     'config': {
         'default': NAME,
@@ -891,14 +892,43 @@ SECTIONS['compress'] = {
 }
 
 SECTIONS['denoise'] = {
+    'images': {
+        'default': None,
+        'type': str,
+        'help': "Location with input images",
+        'metavar': 'PATH'},
+    'denoise-search-radius': {
+        'default': 10,
+        'type': restrict_value((1, 8192), dtype=int),
+        'help': "Search radius in pixels"},
+    'denoise-patch-radius': {
+        'default': 3,
+        'type': restrict_value((1, 100), dtype=int),
+        'help': "Patch radius in pixels"},
+    'denoise-h': {
+        'default': 0.1,
+        'type': restrict_value((0, None)),
+        'help': "Smoothing control parameter, should be around noise standard deviation or slightly less"},
     'denoise-sigma': {
-        'default': None,
-        'type': float,
-        'help': "Sigma parameter"},
-    'denoise-strength': {
-        'default': None,
-        'type': float,
-        'help': "Denoising strength"},
+        'default': 0.0,
+        'type': restrict_value((0, None)),
+        'help': "Noise standard deviation"},
+    'denoise-window': {
+        'default': False,
+        'action': 'store_true',
+        'help': "Use Gaussian window by computing patch weights"},
+    'denoise-fast': {
+        'default': False,
+        'action': 'store_true',
+        'help': "Use a faster version of the algorithm"},
+    'denoise-estimate-sigma': {
+        'default': False,
+        'action': 'store_true',
+        'help': "Estimate noise standard deviation"},
+    'denoise-addressing-mode': {
+        'choices': ['none', 'clamp', 'clamp_to_edge', 'repeat', 'mirrored_repeat'],
+        'default': 'mirrored_repeat',
+        'help': "Outlier treatment"},
 }
 
 SECTIONS['ez'] = {

--- a/tofu/config.py
+++ b/tofu/config.py
@@ -876,22 +876,18 @@ SECTIONS['compress'] = {
         'default': None,
         'type': float,
         'help': "Center parameter"},
-    'compress-softmin': {
-        'default': None,
-        'type': float,
-        'help': "Input dynamic range lower value (if not specified determined based on --compress-input-percentile)"},
-    'compress-softmax': {
-        'default': None,
-        'type': float,
-        'help': "Input dynamic range upper value (if not specified determined based on --compress-input-percentile)"},
     'compress-input-percentile': {
         'default': 0.1,
         'type': restrict_value((0, 100)),
-        'help': "Input percentile from 0 to 100 that defines softmin and softmax."},
-    'compress-auto': {
+        'help': "Input percentile from 0 to 100 that defines softmin and softmax"},
+    'compress-analyze': {
         'default': False,
         'action': 'store_true',
-        'help': "Automatically determine compression parameters"},
+        'help': "Analyze input data, do not do actual processing"},
+    'compress-visualize': {
+        'default': False,
+        'action': 'store_true',
+        'help': "After analysis of the input data, visualize the results"},
 }
 
 SECTIONS['denoise'] = {

--- a/tofu/config.py
+++ b/tofu/config.py
@@ -57,6 +57,12 @@ SECTIONS['general'] = {
         'help': "Maximum bytes per file (0=single-image output, otherwise multi-image output)\
                 , 'k', 'm', 'g', 't' suffixes can be used",
         'metavar': 'BYTESPERFILE'},
+    'output-jpeg2000-threads': {
+        'default': 0,
+        'type': restrict_value((0, None), dtype=int),
+        'help': "Number of OpenJPEG worker threads for JPEG 2000-compressed TIFF output "
+                "(0 uses all available processors)",
+        'metavar': 'THREADS'},
     'output-append': {
         'default': False,
         'action': 'store_true',
@@ -73,6 +79,12 @@ SECTIONS['general'] = {
         'help': "Input width"}}
 
 SECTIONS['reading'] = {
+    'jpeg2000-threads': {
+        'default': 0,
+        'type': restrict_value((0, None), dtype=int),
+        'help': "Number of OpenJPEG worker threads for JPEG 2000-compressed TIFF input "
+                "(0 uses all available processors)",
+        'metavar': 'THREADS'},
     'y': {
         'default': 0,
         'ezdefault': 100,

--- a/tofu/config.py
+++ b/tofu/config.py
@@ -951,6 +951,29 @@ SECTIONS['denoise'] = {
         'help': "Outlier treatment"},
 }
 
+SECTIONS['reconstruction-output'] = {
+    'compress-output': {
+        'default': False,
+        'action': 'store_true',
+        'help': "Compand reconstruction output and write it as JPEG 2000-compressed TIFF"},
+    **{
+        name: SECTIONS['compress'][name]
+        for name in (
+            'compress-bits',
+            'compress-compander',
+            'compress-delta',
+            'compress-j2k-rmse',
+            'compress-center',
+        )
+    },
+}
+
+SECTIONS['reconstruction-denoise'] = {
+    name: options
+    for name, options in SECTIONS['denoise'].items()
+    if name != 'images'
+}
+
 SECTIONS['ez'] = {
     'ezvars': {
         'default': None,
@@ -959,11 +982,17 @@ SECTIONS['ez'] = {
         'metavar': 'PATH'},
 }
 
-TOMO_PARAMS = ('flat-correction', 'reconstruction', 'tomographic-reconstruction', 'fbp', 'dfi', 'ir', 'sart', 'sbtv')
+TOMO_PARAMS = ('flat-correction', 'reconstruction', 'tomographic-reconstruction', 'fbp',
+               'dfi', 'ir', 'sart', 'sbtv', 'reconstruction-output',
+               'reconstruction-denoise')
 
 PREPROC_PARAMS = ('preprocess', 'cone-beam-weight', 'flat-correction', 'retrieve-phase')
 LAMINO_PARAMS = PREPROC_PARAMS + ('laminographic-reconstruction',)
-GEN_RECO_PARAMS = PREPROC_PARAMS + ('general-reconstruction',)
+GEN_RECO_PARAMS = PREPROC_PARAMS + (
+    'general-reconstruction',
+    'reconstruction-output',
+    'reconstruction-denoise',
+)
 
 NICE_NAMES = ('General', 'Input', 'Flat field correction', 'Phase retrieval',
               'Sinogram generation', 'General reconstruction', 'Tomographic reconstruction',
@@ -971,7 +1000,8 @@ NICE_NAMES = ('General', 'Input', 'Flat field correction', 'Phase retrieval',
               'Direct Fourier Inversion', 'Iterative reconstruction',
               'SART', 'SBTV', 'GUI settings', 'Estimation', 'Performance',
               'Preprocess', 'Cone beam weight', 'General reconstruction', 'Find large spots',
-              'Inpaint', 'Compression', 'Denoising', 'EZ')
+              'Inpaint', 'Compression', 'Denoising', 'Reconstruction output',
+              'Reconstruction denoising', 'EZ')
 
 
 # Add unit info to help strings

--- a/tofu/denoise.py
+++ b/tofu/denoise.py
@@ -1,0 +1,2 @@
+def denoise(args):
+    pass

--- a/tofu/denoise.py
+++ b/tofu/denoise.py
@@ -18,7 +18,7 @@ def set_denoise_props(denoise_task, args):
         'h': args.denoise_h,
         'sigma': args.denoise_sigma,
         'window': args.denoise_window,
-        'fast': args.denoise_fast,
+        'fast': True,
         'estimate_sigma': args.denoise_estimate_sigma,
         'addressing_mode': args.denoise_addressing_mode,
     }

--- a/tofu/denoise.py
+++ b/tofu/denoise.py
@@ -1,2 +1,53 @@
+"""Non-local means denoising."""
+import logging
+
+from gi.repository import Ufo
+
+from tofu.tasks import get_task, get_writer
+from tofu.util import run_scheduler, set_node_props, setup_read_task
+
+
+LOG = logging.getLogger(__name__)
+
+
+def set_denoise_props(denoise_task, args):
+    """Set UFO denoising properties from prefixed tofu arguments."""
+    props = {
+        'search_radius': args.denoise_search_radius,
+        'patch_radius': args.denoise_patch_radius,
+        'h': args.denoise_h,
+        'sigma': args.denoise_sigma,
+        'window': args.denoise_window,
+        'fast': args.denoise_fast,
+        'estimate_sigma': args.denoise_estimate_sigma,
+        'addressing_mode': args.denoise_addressing_mode,
+    }
+
+    denoise_task.set_properties(**props)
+
+
+def create_denoising_pipeline(args, processing_node=None):
+    """Create the UFO denoising task."""
+    denoise_task = get_task('non-local-means', processing_node=processing_node)
+    set_denoise_props(denoise_task, args)
+
+    return denoise_task
+
+
 def denoise(args):
-    pass
+    """Run non-local means denoising."""
+    graph = Ufo.TaskGraph()
+    sched = Ufo.Scheduler()
+
+    reader = get_task('read')
+    set_node_props(reader, args)
+    if not args.images:
+        raise RuntimeError('--images not set')
+    setup_read_task(reader, args.images, args)
+
+    out_task = get_writer(args)
+    current = create_denoising_pipeline(args)
+    graph.connect_nodes(reader, current)
+    graph.connect_nodes(current, out_task)
+
+    run_scheduler(sched, graph)

--- a/tofu/genreco.py
+++ b/tofu/genreco.py
@@ -15,6 +15,8 @@ from .util import (fbp_filtering_in_phase_retrieval, get_filtering_padding,
                    get_reconstructed_cube_shape, get_reconstruction_regions,
                    get_filenames, determine_shape, get_scarray_value, Vector)
 from .tasks import get_task, get_writer
+from .compress import (configure_output_writer, create_output_processing_pipeline,
+                       get_output_jpeg2000_level)
 
 
 LOG = logging.getLogger(__name__)
@@ -229,13 +231,6 @@ def setup_graph(args, graph, x_region, y_region, region, source=None, gpu=None, 
                 index=0, make_reader=True):
     backproject = get_task('general-backproject', processing_node=gpu)
 
-    if do_output:
-        if args.dry_run:
-            sink = get_task('null', processing_node=gpu, download=True)
-        else:
-            sink = get_writer(args)
-            sink.props.filename = '{}-{:>03}-%04i.tif'.format(args.output, index)
-
     width = args.width
     height = args.height
     if args.transpose_input:
@@ -298,11 +293,17 @@ def setup_graph(args, graph, x_region, y_region, region, source=None, gpu=None, 
     else:
         source = backproject
 
+    last = create_output_processing_pipeline(args, graph, backproject, processing_node=gpu)
+
     if do_output:
-        graph.connect_nodes(backproject, sink)
+        if args.dry_run:
+            sink = get_task('null', processing_node=gpu, download=True)
+        else:
+            sink = get_writer(args)
+            sink.props.filename = '{}-{:>03}-%04i.tif'.format(args.output, index)
+            configure_output_writer(sink, args)
+        graph.connect_nodes(last, sink)
         last = sink
-    else:
-        last = backproject
 
     return (source, last)
 
@@ -473,7 +474,20 @@ class Executor(object):
                 LOG.debug('Abort requested in writing of region %s', self.region)
                 return
             buf = self.output.get_output_buffer()
-            self.writer.save(ufo.numpy.asarray(buf))
+            image = ufo.numpy.asarray(buf)
+            if getattr(self.args, 'compress_output', False):
+                dtype = np.uint8 if self.args.compress_bits == 8 else np.uint16
+                image = np.rint(image).astype(dtype)
+                self.writer.write(
+                    image,
+                    compression='jpeg2000',
+                    compressionargs={
+                        'level': get_output_jpeg2000_level(self.args),
+                        'numthreads': getattr(self.args, 'output_jpeg2000_threads', 0),
+                    },
+                )
+            else:
+                self.writer.write(image)
             self.output.release_output_buffer(buf)
 
         self.finished.set()

--- a/tofu/metrics.py
+++ b/tofu/metrics.py
@@ -1,5 +1,7 @@
 import numpy as np
 from skimage.restoration import estimate_sigma
+from scipy.ndimage import correlate, convolve
+from numpy.fft import fft2, ifft2, fftshift
 
 
 def _as_float_array(image):
@@ -39,3 +41,56 @@ def get_psnr(data_range, rmse):
 def get_sigma(image):
     """Return the standard deviation of image noise."""
     return estimate_sigma(image)
+
+
+def get_pearson_correlation(image, kernel, fast=True):
+    """Get Pearson correlation coefficient between *image* and *kernel*. It is normalized to (-1,
+    1).
+    """
+    image = image.astype(float)
+    kernel = kernel - kernel.mean()
+    box_kernel = np.ones(kernel.shape, dtype=float) / kernel.size
+
+    if fast:
+        hk, wk = kernel.shape
+        hkh, wkh = hk // 2, wk // 2
+        addition = (hk % 2, wk % 2)
+        padded = np.pad(image, ((hk // 2, hk // 2), (wk // 2, wk // 2)), mode="reflect")
+        h, w = padded.shape
+        kernel_padding = ((h - hk) // 2, (w - wk) // 2)
+        padded_kernel = fftshift(
+            np.pad(
+                kernel,
+                (
+                    (kernel_padding[0] + addition[0], kernel_padding[0]),
+                    (kernel_padding[1] + addition[1], kernel_padding[1]),
+                ),
+                mode="constant"
+            )
+        )
+
+        padded_box_kernel = fftshift(
+            np.pad(
+                box_kernel,
+                (
+                    (kernel_padding[0] + addition[0], kernel_padding[0]),
+                    (kernel_padding[1] + addition[1], kernel_padding[1]),
+                ),
+                mode="constant"
+            )
+        )
+
+        # Normalizations by local image means and standard deviations can be realized by additional
+        # convolutions with a box function.
+        corr = ifft2(fft2(padded) * np.conj(fft2(padded_kernel))).real[hkh:-hkh, wkh:-wkh]
+        im_means = ifft2(fft2(padded) * fft2(padded_box_kernel)).real[hkh:-hkh, wkh:-wkh]
+        im_squares = ifft2(fft2(padded ** 2) * fft2(padded_box_kernel)).real[hkh:-hkh, wkh:-wkh]
+    else:
+        # Mainly for debugging
+        corr = correlate(image, kernel, mode="reflect")
+        im_means = convolve(image.astype(float), box_kernel)
+        im_squares = convolve(image.astype(float) ** 2, box_kernel)
+
+    im_std = np.sqrt(im_squares - im_means ** 2)
+
+    return corr / (im_std * np.std(kernel) * kernel.size)

--- a/tofu/metrics.py
+++ b/tofu/metrics.py
@@ -1,0 +1,41 @@
+import numpy as np
+from skimage.restoration import estimate_sigma
+
+
+def _as_float_array(image):
+    """Return *image* as a floating-point NumPy array."""
+    return np.asarray(image, dtype=np.float64)
+
+
+def _check_matching_shapes(reference, image):
+    """Raise an error if *reference* and *image* do not have the same shape."""
+    if reference.shape != image.shape:
+        raise ValueError(
+            "Images must have the same shape, got {} and {}".format(
+                reference.shape, image.shape
+            )
+        )
+
+
+def get_mse(reference, image):
+    """Return the mean squared error between a reference image and an image."""
+    reference = _as_float_array(reference)
+    image = _as_float_array(image)
+    _check_matching_shapes(reference, image)
+
+    return np.mean((reference - image) ** 2)
+
+
+def get_rmse(reference, image):
+    """Return the root mean squared error between a reference image and an image."""
+    return np.sqrt(get_mse(reference, image))
+
+
+def get_psnr(data_range, rmse):
+    """Compute the peak signal-to-noise ratio from *data_range* and *rmse*."""
+    return 20 * np.log10(data_range / rmse)
+
+
+def get_sigma(image):
+    """Return the standard deviation of image noise."""
+    return estimate_sigma(image)

--- a/tofu/reco.py
+++ b/tofu/reco.py
@@ -9,6 +9,7 @@ from tofu.preprocess import create_flat_correct_pipeline
 from tofu.util import (set_node_props, setup_read_task, get_filenames,
                        read_image, determine_shape, setup_padding, run_scheduler)
 from tofu.tasks import get_task, get_writer
+from tofu.compress import configure_output_writer, create_output_processing_pipeline
 
 
 LOG = logging.getLogger(__name__)
@@ -68,9 +69,14 @@ def tomo(params):
     LOG.debug("Input dimensions: {}x{} pixels".format(width, height))
 
     writer = get_writer(params)
+    configure_output_writer(writer, params)
 
     # Setup graph depending on the chosen method and input data
     g = Ufo.TaskGraph()
+
+    def connect_output(current):
+        current = create_output_processing_pipeline(params, g, current)
+        g.connect_nodes(current, writer)
 
     if params.projections is not None:
         if params.number:
@@ -145,7 +151,7 @@ def tomo(params):
             g.connect_nodes(fltr, ifft)
             g.connect_nodes(ifft, bp)
 
-        g.connect_nodes(last_node, writer)
+        connect_output(last_node)
 
     if params.method in ('sart', 'sirt', 'sbtv', 'asdpocs'):
         projector = pm.get_task_from_package('ir', 'parallel-projector')
@@ -171,7 +177,7 @@ def tomo(params):
             method.set_properties(mu=params.mu)
 
         g.connect_nodes(sino_output, method)
-        g.connect_nodes(method, writer)
+        connect_output(method)
 
     if params.method == 'dfi':
         oversampling = params.oversampling or 1
@@ -196,9 +202,9 @@ def tomo(params):
             crop = get_task('crop')
             crop.set_properties(from_center=True, width=width, height=width)
             g.connect_nodes(swap_backward, crop)
-            g.connect_nodes(crop, writer)
+            connect_output(crop)
         else:
-            g.connect_nodes(swap_backward, writer)
+            connect_output(swap_backward)
 
     scheduler = Ufo.Scheduler()
 

--- a/tofu/tasks.py
+++ b/tofu/tasks.py
@@ -41,6 +41,8 @@ def get_writer(params):
         writer.props.bytes_per_file = params.output_bytes_per_file
     if hasattr(writer.props, 'tiff_bigtiff'):
         writer.props.tiff_bigtiff = params.output_bytes_per_file > 2 ** 32 - 2 ** 25
+    if hasattr(writer.props, 'jpeg2000_threads'):
+        writer.props.jpeg2000_threads = getattr(params, 'output_jpeg2000_threads', 0)
 
     return writer
 

--- a/tofu/tests/test_jpeg2000_threads.py
+++ b/tofu/tests/test_jpeg2000_threads.py
@@ -1,0 +1,69 @@
+import argparse
+
+from tofu import config, tasks, util
+
+
+class Params(argparse.Namespace):
+    def __contains__(self, name):
+        return hasattr(self, name)
+
+
+class Props:
+    jpeg2000_threads = 0
+
+
+class Task:
+    def __init__(self):
+        self.props = Props()
+
+
+def test_jpeg2000_thread_arguments():
+    parser = argparse.ArgumentParser()
+    config.Params().add_arguments(parser)
+
+    defaults = parser.parse_args([])
+    assert defaults.jpeg2000_threads == 0
+    assert defaults.output_jpeg2000_threads == 0
+
+    args = parser.parse_args(
+        ["--jpeg2000-threads", "3", "--output-jpeg2000-threads", "5"]
+    )
+    assert args.jpeg2000_threads == 3
+    assert args.output_jpeg2000_threads == 5
+
+
+def test_setup_read_task_sets_jpeg2000_threads(monkeypatch):
+    task = Task()
+    monkeypatch.setattr(util, "get_filenames", lambda path: [])
+
+    util.setup_read_task(task, "input.tif", Params(jpeg2000_threads=3))
+
+    assert task.props.path == "input.tif"
+    assert task.props.jpeg2000_threads == 3
+
+
+def test_get_writer_sets_jpeg2000_threads(monkeypatch):
+    writer = Task()
+    writer.props.append = False
+    writer.props.bits = 32
+    writer.props.minimum = 0
+    writer.props.maximum = 0
+    writer.props.rescale = False
+    writer.props.bytes_per_file = 0
+    writer.props.tiff_bigtiff = False
+    monkeypatch.setattr(tasks, "get_task", lambda *args, **kwargs: writer)
+
+    params = Params(
+        dry_run=False,
+        output="output.tif",
+        output_append=False,
+        output_bitdepth=32,
+        output_minimum=None,
+        output_maximum=None,
+        output_rescale=False,
+        output_bytes_per_file=1024,
+        output_jpeg2000_threads=5,
+    )
+
+    assert tasks.get_writer(params) is writer
+    assert writer.props.jpeg2000_threads == 5

--- a/tofu/tests/test_reconstruction_postprocessing.py
+++ b/tofu/tests/test_reconstruction_postprocessing.py
@@ -1,0 +1,123 @@
+from types import SimpleNamespace
+
+import pytest
+
+from tofu import compress, config
+
+
+class Props(SimpleNamespace):
+    def __contains__(self, name):
+        return hasattr(self, name)
+
+
+class Task:
+    def __init__(self, name):
+        self.name = name
+        self.props = Props(
+            bits=32,
+            level=0,
+            rescale=True,
+            tiff_jpeg2000=False,
+        )
+
+
+class Graph:
+    def __init__(self):
+        self.connections = []
+
+    def connect_nodes(self, source, target):
+        self.connections.append((source.name, target.name))
+
+
+def make_args(**overrides):
+    values = {
+        'compress_output': True,
+        'compress_bits': 16,
+        'compress_compander': 'tanh',
+        'compress_center': 1.5,
+        'compress_delta': 0.25,
+        'compress_j2k_rmse': None,
+        'denoise': False,
+        'denoise_compression_aware': False,
+        'dry_run': False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_reconstruction_commands_expose_postprocessing_options():
+    tomo = config.Params(config.TOMO_PARAMS).get_defaults()
+    reco = config.Params(config.GEN_RECO_PARAMS).get_defaults()
+
+    for args in (tomo, reco):
+        assert args.compress_output is False
+        assert args.denoise is False
+        assert args.compress_bits == 16
+
+
+def test_output_pipeline_adds_denoise_before_compand(monkeypatch):
+    graph = Graph()
+    source = Task('reconstruction')
+    denoise = Task('denoise')
+    compand = Task('compand')
+    args = make_args(denoise=True)
+
+    monkeypatch.setattr(
+        compress,
+        'create_denoising_pipeline',
+        lambda args, processing_node=None: denoise,
+    )
+    monkeypatch.setattr(
+        compress.TanhCompander,
+        'create_ufo_task',
+        lambda self, direction='forward', processing_node=None: compand,
+    )
+
+    result = compress.create_output_processing_pipeline(args, graph, source)
+
+    assert result is compand
+    assert graph.connections == [
+        ('reconstruction', 'denoise'),
+        ('denoise', 'compand'),
+    ]
+
+
+def test_output_companding_requires_explicit_center_and_delta():
+    graph = Graph()
+    source = Task('reconstruction')
+
+    with pytest.raises(RuntimeError, match='--compress-center'):
+        compress.create_output_processing_pipeline(
+            make_args(compress_center=None),
+            graph,
+            source,
+        )
+
+    with pytest.raises(RuntimeError, match='--compress-delta'):
+        compress.create_output_processing_pipeline(
+            make_args(compress_delta=None),
+            graph,
+            source,
+        )
+
+
+def test_output_writer_uses_lossless_jpeg2000_by_default():
+    writer = Task('writer')
+
+    compress.configure_output_writer(writer, make_args())
+
+    assert writer.props.bits == 16
+    assert writer.props.rescale is False
+    assert writer.props.tiff_jpeg2000 is True
+    assert writer.props.level == 0
+
+
+def test_compression_aware_denoising_requires_companded_output():
+    args = make_args(
+        compress_output=False,
+        denoise=True,
+        denoise_compression_aware=True,
+    )
+
+    with pytest.raises(RuntimeError, match='requires --compress-output'):
+        compress.create_output_processing_pipeline(args, Graph(), Task('reconstruction'))

--- a/tofu/util.py
+++ b/tofu/util.py
@@ -4,6 +4,7 @@ import gi
 import glob
 import logging
 import math
+import numpy as np
 import os
 from collections import OrderedDict
 try:
@@ -174,7 +175,7 @@ def next_power_of_two(number):
     return 2 ** int(math.ceil(math.log(number, 2)))
 
 
-def read_image(filename, allow_multi=False):
+def read_image(filename, image_start=0, image_step=1, allow_multi=False):
     """Read image from file *filename*. In case of tif files, *filename* can be a regular expression
     matching more files. If *allow_multi* is True and there are more images in the *filename*,
     return them all, not only the first one.
@@ -186,8 +187,10 @@ def read_image(filename, allow_multi=False):
 
     if format_check.lower().endswith('.tif') or format_check.lower().endswith('.tiff'):
         reader = TiffSequenceReader(filename)
-        images = [reader.read(i) for i in range(reader.num_images)]
-        return images if allow_multi else images[0]
+        if allow_multi:
+            return np.array([reader.read(i) for i in range(image_start, reader.num_images, image_step)])
+        else:
+            return reader.read(0)
     elif '.edf' in format_check.lower():
         import fabio
         edf = fabio.edfimage.edfimage()

--- a/tofu/util.py
+++ b/tofu/util.py
@@ -175,10 +175,10 @@ def next_power_of_two(number):
     return 2 ** int(math.ceil(math.log(number, 2)))
 
 
-def read_image(filename, image_start=0, image_step=1, allow_multi=False):
+def read_image(filename, args=None, allow_multi=False):
     """Read image from file *filename*. In case of tif files, *filename* can be a regular expression
     matching more files. If *allow_multi* is True and there are more images in the *filename*,
-    return them all, not only the first one.
+    return them all, not only the first one. Use region info from *args*.
     """
     if os.path.isdir(filename):
         format_check = glob.glob(os.path.join(filename, "*"))[0]
@@ -187,10 +187,19 @@ def read_image(filename, image_start=0, image_step=1, allow_multi=False):
 
     if format_check.lower().endswith('.tif') or format_check.lower().endswith('.tiff'):
         reader = TiffSequenceReader(filename)
-        if allow_multi:
-            return np.array([reader.read(i) for i in range(image_start, reader.num_images, image_step)])
-        else:
-            return reader.read(0)
+        num = args.number if args and allow_multi else 1
+        if num is None:
+            num = reader.num_images
+        start = args.image_start if args else 0
+        step = args.image_step if args else 1
+        images = np.array([reader.read(i) for i in range(start, num, step)])
+        height = args.height if args.height else images.shape[-2]
+        if args:
+            # TODO: support width
+            images = images[:, args.y:args.y + height:args.y_step, args.y:args.y + height]
+        if not allow_multi:
+            images = images[0]
+        return images
     elif '.edf' in format_check.lower():
         import fabio
         edf = fabio.edfimage.edfimage()

--- a/tofu/util.py
+++ b/tofu/util.py
@@ -82,6 +82,8 @@ def get_filenames(path):
 def setup_read_task(task, path, args):
     """Set up *task* and take care of handling file types correctly."""
     task.props.path = path
+    if hasattr(task.props, 'jpeg2000_threads'):
+        task.props.jpeg2000_threads = getattr(args, 'jpeg2000_threads', 0)
 
     fnames = get_filenames(path)
 


### PR DESCRIPTION
## Summary

This adds post-processing commands for compressing reconstructed image data with reversible tone mapping, quantization, and JPEG 2000 encoding. The prerequisite is the [ufo-filters](https://github.com/ufo-kit/ufo-filters/pull/246) support.

## Changes

- Added `tofu compress`, `tofu decompress` and `tofu denoise`.
- Added companders for `tanh`, `arctan`, `recip_sqrt`, and `clip` tone mapping.
- Added automatic analysis of representative images to estimate center, delta, noise sigma, quantization error, JPEG 2000 RMSE, and full round-trip RMSE.
- Added optional PyQtGraph visualization for the companded image preview and tone-curve inspection.
- Added optional non-local-means denoising support through `tofu denoise` and compression preprocessing.
- Added image quality helpers for sigma, RMSE, PSNR, and related metrics.
- Added compression, decompression, and denoising CLI/config options.
- Added post-processing documentation with a typical analyze-then-compress workflow.

## Disclaimer

Parts of this PR were AI-generated.